### PR TITLE
fix(pwa): safe-area-inset-top for Dynamic Island

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -85,8 +85,9 @@
 }
 
 /* iOS Safari: safe-area support for notch/Dynamic Island devices */
-@supports (padding: env(safe-area-inset-bottom)) {
+@supports (padding: env(safe-area-inset-top)) {
 	:root {
+		--safe-area-top: env(safe-area-inset-top, 0px);
 		--safe-area-bottom: env(safe-area-inset-bottom, 0px);
 	}
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -66,15 +66,16 @@
 	<!-- Desktop sidebar -->
 	<Sidebar projects={data.projects} areas={data.areas} />
 
-	<!-- Main content area -->
+	<!-- Main content area — safe-area-inset-top for standalone PWA on notch devices -->
 	<main
-		class="flex-1 overflow-y-auto pb-16 lg:pb-0 has-[data-chat-thread]:overflow-hidden has-[data-chat-thread]:pb-0"
+		class="flex-1 overflow-y-auto pb-16 lg:pb-0 has-[data-chat-thread]:overflow-hidden has-[data-chat-thread]:pb-0 has-[data-chat-thread]:pt-0"
+		style="padding-top: env(safe-area-inset-top, 0px);"
 	>
 		{@render children()}
 	</main>
 
-	<!-- Notification bell — fixed top-right -->
-	<div class="fixed top-2 right-3 z-40">
+	<!-- Notification bell — fixed top-right, offset for safe-area -->
+	<div class="fixed right-3 z-40" style="top: max(0.5rem, env(safe-area-inset-top, 0.5rem));">
 		<NotificationBell bind:this={notificationBellRef} />
 	</div>
 

--- a/src/routes/areas/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/areas/[slug]/chats/[threadId]/+page.svelte
@@ -471,9 +471,10 @@
 </script>
 
 <div class="flex flex-col h-[100dvh] md:h-full" data-testid="mobile-chat-page" data-chat-thread>
-	<!-- ── Chat Header (AC-18) ──────────────────────────────────────────── -->
+	<!-- ── Chat Header (AC-18) — safe-area-inset-top for standalone PWA ── -->
 	<header
 		class="flex items-center gap-1 px-1 py-1 border-b border-border flex-shrink-0 bg-card min-h-[52px]"
+		style="padding-top: env(safe-area-inset-top, 0px);"
 		data-testid="chat-header"
 	>
 		<!-- Back button (AC-11) — 44×44 touch target -->

--- a/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
@@ -471,9 +471,10 @@
 </script>
 
 <div class="flex flex-col h-[100dvh] md:h-full" data-testid="mobile-chat-page" data-chat-thread>
-	<!-- ── Chat Header (AC-18) ──────────────────────────────────────────── -->
+	<!-- ── Chat Header (AC-18) — safe-area-inset-top for standalone PWA ── -->
 	<header
 		class="flex items-center gap-1 px-1 py-1 border-b border-border flex-shrink-0 bg-card min-h-[52px]"
+		style="padding-top: env(safe-area-inset-top, 0px);"
 		data-testid="chat-header"
 	>
 		<!-- Back button (AC-11) — 44×44 touch target -->


### PR DESCRIPTION
## Summary
- Adds `padding-top: env(safe-area-inset-top)` to root layout for standalone PWA on notch devices
- Adds safe-area-inset-top to both project and area mobile chat headers
- Offsets notification bell below safe-area zone
- Adds `--safe-area-top` CSS variable

Fixes Loom issues 3 (dashboard behind notch), 4 (project page behind notch), 5 (chat inaccessible).

## Test plan
- [ ] Dashboard content visible below Dynamic Island in standalone PWA
- [ ] Project page title + tabs visible below notch
- [ ] Chat back button + title visible below notch
- [ ] Area chat page same fix applied
- [ ] Desktop: no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS and standalone PWA layout compatibility by properly accounting for safe-area insets. Content no longer overlaps with device notches and status bars. Updated notification bell positioning and chat headers to respect device-specific top spacing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->