### PR TITLE
feat(auth): cookie session auth for PWA

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -11,6 +11,9 @@ services:
       PORT: '3000'
       HOST: '0.0.0.0'
       ORACLE_DATA_PATH: /opt/oracle/data
+      ORACLE_AUTH_USERNAME: ${ORACLE_AUTH_USERNAME}
+      ORACLE_AUTH_PASSWORD: ${ORACLE_AUTH_PASSWORD}
+      ORACLE_AUTH_SECRET: ${ORACLE_AUTH_SECRET}
       TZ: America/Los_Angeles
     volumes:
       - oracle_data:/opt/oracle/data
@@ -25,13 +28,10 @@ services:
       # The container is on multiple networks (oracle-stack_default + root_default);
       # without this, Traefik can pick the wrong one and silently fail to route.
       - 'traefik.docker.network=root_default'
-      # HTTP Basic Auth — users loaded from .env at deploy time.
-      # Required per Warden review (ORACLE#22). App is single-user and contains
-      # private PARA data, so public access is not acceptable.
-      - 'traefik.http.routers.oracle.middlewares=oracle-auth'
-      - 'traefik.http.middlewares.oracle-auth.basicauth.users=${ORACLE_BASIC_AUTH_USERS}'
-      - 'traefik.http.middlewares.oracle-auth.basicauth.realm=Oracle'
-      - 'traefik.http.middlewares.oracle-auth.basicauth.removeheader=true'
+      # Auth is now handled by the app (cookie session) instead of Traefik.
+      # Basic auth removed — it doesn't re-prompt in iOS standalone PWA mode,
+      # causing blank white screen on session expiry (Loom issue 1).
+      # App-level auth: hooks.server.ts checks cookie, redirects to /login.
     healthcheck:
       # Use 127.0.0.1 not localhost — Alpine resolves localhost to ::1 (IPv6),
       # but the SvelteKit Node adapter only binds IPv4 (0.0.0.0). busybox wget

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,30 @@
+import type { Handle } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
+import { COOKIE_NAME, validateSessionToken } from '$lib/server/auth';
+
+/** Routes that don't require authentication. */
+const PUBLIC_PATHS = ['/login', '/api/health', '/api/auth'];
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const { pathname } = event.url;
+
+	// Allow public paths through without auth
+	if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
+		return resolve(event);
+	}
+
+	// Check session cookie
+	const token = event.cookies.get(COOKIE_NAME);
+	if (!token) {
+		throw redirect(303, '/login');
+	}
+
+	const username = validateSessionToken(token);
+	if (!username) {
+		// Invalid or expired — clear the bad cookie and redirect
+		event.cookies.delete(COOKIE_NAME, { path: '/' });
+		throw redirect(303, '/login');
+	}
+
+	return resolve(event);
+};

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,0 +1,48 @@
+import { env } from '$env/dynamic/private';
+import { createHmac } from 'crypto';
+
+const COOKIE_NAME = 'oracle_session';
+const MAX_AGE_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+function getSecret(): string {
+	const secret = env.ORACLE_AUTH_SECRET;
+	if (!secret) throw new Error('ORACLE_AUTH_SECRET is not set');
+	return secret;
+}
+
+function sign(payload: string): string {
+	return createHmac('sha256', getSecret()).update(payload).digest('hex');
+}
+
+/** Validate credentials against environment variables. */
+export function validateCredentials(username: string, password: string): boolean {
+	const expectedUser = env.ORACLE_AUTH_USERNAME;
+	const expectedPass = env.ORACLE_AUTH_PASSWORD;
+	if (!expectedUser || !expectedPass) return false;
+	return username === expectedUser && password === expectedPass;
+}
+
+/** Create a signed session cookie value. */
+export function createSessionToken(username: string): string {
+	const ts = Date.now().toString();
+	const sig = sign(`${username}:${ts}`);
+	return `${username}:${ts}:${sig}`;
+}
+
+/** Validate a session cookie value. Returns the username or null. */
+export function validateSessionToken(token: string): string | null {
+	const parts = token.split(':');
+	if (parts.length !== 3) return null;
+	const [username, ts, sig] = parts;
+	const expected = sign(`${username}:${ts}`);
+	if (sig !== expected) return null;
+
+	// Check expiry
+	const created = parseInt(ts, 10);
+	if (isNaN(created)) return null;
+	if (Date.now() - created > MAX_AGE_SECONDS * 1000) return null;
+
+	return username;
+}
+
+export { COOKIE_NAME, MAX_AGE_SECONDS };

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import {
+	validateCredentials,
+	createSessionToken,
+	COOKIE_NAME,
+	MAX_AGE_SECONDS
+} from '$lib/server/auth';
+
+export const POST: RequestHandler = async ({ request, cookies }) => {
+	const body = await request.json();
+	const { username, password } = body as { username?: string; password?: string };
+
+	if (!username || !password) {
+		return json({ error: 'Username and password required' }, { status: 400 });
+	}
+
+	if (!validateCredentials(username, password)) {
+		return json({ error: 'Invalid credentials' }, { status: 401 });
+	}
+
+	const token = createSessionToken(username);
+	cookies.set(COOKIE_NAME, token, {
+		path: '/',
+		httpOnly: true,
+		secure: true,
+		sameSite: 'lax',
+		maxAge: MAX_AGE_SECONDS
+	});
+
+	return json({ ok: true });
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+
+	let username = $state('');
+	let password = $state('');
+	let error = $state('');
+	let loading = $state(false);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+		loading = true;
+
+		try {
+			const res = await fetch('/api/auth/login', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ username, password })
+			});
+
+			if (res.ok) {
+				await goto('/', { replaceState: true });
+			} else {
+				const data = await res.json();
+				error = data.error || 'Login failed';
+			}
+		} catch {
+			error = 'Network error. Please try again.';
+		} finally {
+			loading = false;
+		}
+	}
+</script>
+
+<div
+	class="min-h-screen flex items-center justify-center bg-background px-4"
+	style="padding-top: env(safe-area-inset-top, 0px);"
+>
+	<div class="w-full max-w-sm">
+		<!-- Logo -->
+		<div class="text-center mb-8">
+			<div
+				class="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-primary/10 text-primary text-2xl font-bold mb-4"
+			>
+				O
+			</div>
+			<h1 class="text-xl font-bold text-foreground">Oracle</h1>
+			<p class="text-xs text-muted-foreground mt-1">Personal Operations System</p>
+		</div>
+
+		<!-- Login form -->
+		<form onsubmit={handleSubmit} class="space-y-4">
+			{#if error}
+				<div class="text-sm text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+					{error}
+				</div>
+			{/if}
+
+			<div>
+				<label for="username" class="block text-sm font-medium text-foreground mb-1.5">
+					Username
+				</label>
+				<input
+					id="username"
+					type="text"
+					bind:value={username}
+					autocomplete="username"
+					required
+					class="w-full px-3 py-2.5 rounded-lg border border-border bg-card text-foreground
+						placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+					style="font-size: 16px;"
+					placeholder="Enter username"
+				/>
+			</div>
+
+			<div>
+				<label for="password" class="block text-sm font-medium text-foreground mb-1.5">
+					Password
+				</label>
+				<input
+					id="password"
+					type="password"
+					bind:value={password}
+					autocomplete="current-password"
+					required
+					class="w-full px-3 py-2.5 rounded-lg border border-border bg-card text-foreground
+						placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+					style="font-size: 16px;"
+					placeholder="Enter password"
+				/>
+			</div>
+
+			<button
+				type="submit"
+				disabled={loading || !username || !password}
+				class="w-full py-2.5 rounded-lg bg-primary text-primary-foreground font-semibold
+					hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+			>
+				{loading ? 'Signing in...' : 'Sign in'}
+			</button>
+		</form>
+	</div>
+</div>


### PR DESCRIPTION
## Summary
- Replaces Traefik HTTP Basic Auth with app-level cookie session auth
- Fixes Loom issue 1: blank white screen on session expiry in iOS standalone PWA
- HMAC-signed stateless session tokens (30-day expiry, survives container restarts)
- Darkmatter-themed login page with mobile-first design

## Deploy requirements
Add to `.env` on KVM2:
```
ORACLE_AUTH_USERNAME=nick
ORACLE_AUTH_PASSWORD=<choose-password>
ORACLE_AUTH_SECRET=<random-64-char-hex>
```
Generate secret: `openssl rand -hex 32`

## Test plan
- [ ] Login page renders in standalone PWA on iOS
- [ ] Valid credentials → redirect to dashboard, cookie set
- [ ] Invalid credentials → error shown
- [ ] Expired/missing cookie → redirects to /login (no blank screen)
- [ ] /api/health accessible without auth
- [ ] Cookie persists across container restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a login page where users can authenticate with credentials.
  * Implemented session-based authentication using secure cookies.
  * Protected routes now require valid authentication; unauthenticated requests redirect to login.
  * Public routes (login, health check, auth endpoints) remain accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->