### PR TITLE
fix(ci): Buffer type error in oracle-reader-tasks test

### DIFF
--- a/tests/unit/oracle-reader-tasks.test.ts
+++ b/tests/unit/oracle-reader-tasks.test.ts
@@ -36,7 +36,7 @@ function tasksFile(tasks: Task[]): string {
 }
 
 function mockReadFile(content: string) {
-	vi.mocked(readFile).mockResolvedValueOnce(content as unknown as Buffer);
+	vi.mocked(readFile).mockResolvedValueOnce(Buffer.from(content));
 }
 
 function mockReadFileError(code = 'ENOENT') {


### PR DESCRIPTION
CI runner uses stricter TS than local. `content as unknown as Buffer` fails; `Buffer.from(content)` is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test helper to use proper file content handling, enhancing test reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->