### PR TITLE
fix(tasks): align Pennyworth task URLs with current API contract

### DIFF
--- a/src/lib/server/pennyworth-tasks-client.ts
+++ b/src/lib/server/pennyworth-tasks-client.ts
@@ -58,11 +58,14 @@ export interface PatchTaskBody {
 	sort_order?: number;
 }
 
+function tasksBasePath(oracleSlug: string): string {
+	return `/api/oracle/projects/${encodeURIComponent(oracleSlug)}/tasks`;
+}
+
 // ─── 1. List tasks for a project ─────────────────────────────────────────────
 
 export async function listTasks(baseUrl: string, oracleSlug: string): Promise<Task[]> {
-	const params = new URLSearchParams({ oracle_slug: oracleSlug });
-	const res = await tasksFetch(`${baseUrl}/api/tasks?${params}`);
+	const res = await tasksFetch(`${baseUrl}${tasksBasePath(oracleSlug)}`);
 	const data = (await res.json()) as { tasks: Task[] };
 	return data.tasks;
 }
@@ -74,9 +77,9 @@ export async function createTask(
 	oracleSlug: string,
 	body: CreateTaskBody
 ): Promise<Task> {
-	const res = await tasksFetch(`${baseUrl}/api/tasks`, {
+	const res = await tasksFetch(`${baseUrl}${tasksBasePath(oracleSlug)}`, {
 		method: 'POST',
-		body: JSON.stringify({ ...body, oracle_slug: oracleSlug })
+		body: JSON.stringify(body)
 	});
 	const data = (await res.json()) as { task: Task };
 	return data.task;
@@ -86,33 +89,51 @@ export async function createTask(
 
 export async function patchTask(
 	baseUrl: string,
+	oracleSlug: string,
 	taskId: string,
 	body: PatchTaskBody
 ): Promise<Task> {
-	const res = await tasksFetch(`${baseUrl}/api/tasks/${encodeURIComponent(taskId)}`, {
-		method: 'PATCH',
-		body: JSON.stringify(body)
-	});
+	const res = await tasksFetch(
+		`${baseUrl}${tasksBasePath(oracleSlug)}/${encodeURIComponent(taskId)}`,
+		{
+			method: 'PATCH',
+			body: JSON.stringify(body)
+		}
+	);
 	const data = (await res.json()) as { task: Task };
 	return data.task;
 }
 
 // ─── 4. Delete a task ────────────────────────────────────────────────────────
 
-export async function deleteTask(baseUrl: string, taskId: string): Promise<string> {
-	const res = await tasksFetch(`${baseUrl}/api/tasks/${encodeURIComponent(taskId)}`, {
-		method: 'DELETE'
-	});
+export async function deleteTask(
+	baseUrl: string,
+	oracleSlug: string,
+	taskId: string
+): Promise<string> {
+	const res = await tasksFetch(
+		`${baseUrl}${tasksBasePath(oracleSlug)}/${encodeURIComponent(taskId)}`,
+		{
+			method: 'DELETE'
+		}
+	);
 	const data = (await res.json()) as { deleted: string };
 	return data.deleted;
 }
 
 // ─── 5. Promote a task to a GitHub issue ─────────────────────────────────────
 
-export async function promoteTask(baseUrl: string, taskId: string): Promise<Task> {
-	const res = await tasksFetch(`${baseUrl}/api/tasks/${encodeURIComponent(taskId)}/promote`, {
-		method: 'POST'
-	});
+export async function promoteTask(
+	baseUrl: string,
+	oracleSlug: string,
+	taskId: string
+): Promise<Task> {
+	const res = await tasksFetch(
+		`${baseUrl}${tasksBasePath(oracleSlug)}/${encodeURIComponent(taskId)}/promote`,
+		{
+			method: 'POST'
+		}
+	);
 	const data = (await res.json()) as { task: Task };
 	return data.task;
 }

--- a/src/routes/api/projects/[slug]/tasks/[id]/+server.ts
+++ b/src/routes/api/projects/[slug]/tasks/[id]/+server.ts
@@ -8,7 +8,7 @@ const SLUG_RE = /^[a-z0-9-]+$/;
 /**
  * PATCH /api/projects/[slug]/tasks/[id]
  *
- * Proxies to Pennyworth's `PATCH /api/tasks/:id`.
+ * Proxies to Pennyworth's `PATCH /api/oracle/projects/:slug/tasks/:id`.
  */
 export const PATCH: RequestHandler = async ({ params, request }) => {
 	if (!SLUG_RE.test(params.slug)) {
@@ -34,7 +34,7 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 	}
 
 	try {
-		const task = await patchTask(baseUrl, params.id, body);
+		const task = await patchTask(baseUrl, params.slug, params.id, body);
 		return json({ task });
 	} catch (err) {
 		const message = (err as Error).message;
@@ -48,7 +48,7 @@ export const PATCH: RequestHandler = async ({ params, request }) => {
 /**
  * DELETE /api/projects/[slug]/tasks/[id]
  *
- * Proxies to Pennyworth's `DELETE /api/tasks/:id`.
+ * Proxies to Pennyworth's `DELETE /api/oracle/projects/:slug/tasks/:id`.
  */
 export const DELETE: RequestHandler = async ({ params }) => {
 	if (!SLUG_RE.test(params.slug)) {
@@ -63,7 +63,7 @@ export const DELETE: RequestHandler = async ({ params }) => {
 	}
 
 	try {
-		const deleted = await deleteTask(baseUrl, params.id);
+		const deleted = await deleteTask(baseUrl, params.slug, params.id);
 		return json({ deleted });
 	} catch (err) {
 		const message = (err as Error).message;

--- a/src/routes/api/projects/[slug]/tasks/[id]/promote/+server.ts
+++ b/src/routes/api/projects/[slug]/tasks/[id]/promote/+server.ts
@@ -8,8 +8,9 @@ const SLUG_RE = /^[a-z0-9-]+$/;
 /**
  * POST /api/projects/[slug]/tasks/[id]/promote
  *
- * Proxies to Pennyworth's `POST /api/tasks/:id/promote` which creates a
- * GitHub issue for the task and stores the issue URL in `sync.github_issue`.
+ * Proxies to Pennyworth's `POST /api/oracle/projects/:slug/tasks/:id/promote`
+ * which creates a GitHub issue for the task and stores the issue URL in
+ * `sync.github_issue`.
  */
 export const POST: RequestHandler = async ({ params }) => {
 	if (!SLUG_RE.test(params.slug)) {
@@ -24,7 +25,7 @@ export const POST: RequestHandler = async ({ params }) => {
 	}
 
 	try {
-		const task = await promoteTask(baseUrl, params.id);
+		const task = await promoteTask(baseUrl, params.slug, params.id);
 		return json({ task });
 	} catch (err) {
 		const message = (err as Error).message;


### PR DESCRIPTION
## Summary
- Oracle task board has been silently broken in the web UI since the Pennyworth rename — task client was calling `/api/tasks?oracle_slug=X` but Pennyworth only exposes these endpoints at `/api/oracle/projects/:slug/tasks`
- 5 functions in \`pennyworth-tasks-client.ts\` updated to use the correct URL scheme
- 3 \`+server.ts\` call sites updated to pass \`params.slug\` through to the client

## Root cause
Discovered 2026-04-16 while migrating the PSI Odoo V19 project's task board — freshly-written tasks.json was on disk, served correctly by Pennyworth at the real endpoint, but \`/projects/[slug]/tasks\` returned "Project not found" in the web UI.

Pennyworth side (correct): \`src/api/server.ts\` lines 951, 1005, 1027, 1103, 1144
Oracle App side (broken): single commit 4440762 built against an older/imaginary URL scheme, never updated.

## Test plan
- [ ] Deploy to KVM 2
- [ ] Load \`/projects/psi-odoo-v8-to-v19-upgrade\` — 21 tasks across 8 phases should render
- [ ] Load \`/projects/pai-orchestration\` — existing tasks should render
- [ ] Create a task via the UI → verify it writes to \`tasks.json\` on KVM 2
- [ ] Patch a task (status change) via the UI → verify update
- [ ] Delete a task via the UI → verify removal
- [ ] Promote a task to a GitHub issue → verify issue URL lands in \`sync.github_issue\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured task management API endpoints to include project scope in request paths, improving API organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->