### PR TITLE
fix: task board collapse, DnD reorder, push toggle

### DIFF
--- a/src/lib/components/PullToRefresh.svelte
+++ b/src/lib/components/PullToRefresh.svelte
@@ -1,0 +1,91 @@
+<!--
+	Pull-to-refresh for PWA. Wraps content and shows a spinner when the user
+	pulls down from the top of the scroll container. Calls `onrefresh` which
+	should return a Promise that resolves when data is refreshed.
+
+	Only activates when the scroll container is at the top (scrollTop ≤ 0)
+	so it doesn't interfere with normal scrolling.
+-->
+<script lang="ts">
+	import { RefreshCw } from 'lucide-svelte';
+
+	interface Props {
+		/** Called when the user completes a pull-to-refresh gesture */
+		onrefresh: () => Promise<void>;
+		children: import('svelte').Snippet;
+	}
+
+	const { onrefresh, children }: Props = $props();
+
+	const THRESHOLD = 80;
+
+	let startY = $state(0);
+	let pullDistance = $state(0);
+	let pulling = $state(false);
+	let refreshing = $state(false);
+	let containerEl = $state<HTMLElement | null>(null);
+
+	function onTouchStart(e: TouchEvent) {
+		if (refreshing) return;
+		// Only activate when scrolled to the top
+		if (containerEl && containerEl.scrollTop > 0) return;
+		startY = e.touches[0].clientY;
+		pulling = true;
+	}
+
+	function onTouchMove(e: TouchEvent) {
+		if (!pulling || refreshing) return;
+		const dy = e.touches[0].clientY - startY;
+		if (dy > 0) {
+			pullDistance = Math.min(dy * 0.5, 120); // dampen
+			if (dy > 10) e.preventDefault();
+		} else {
+			pullDistance = 0;
+		}
+	}
+
+	async function onTouchEnd() {
+		if (!pulling) return;
+		pulling = false;
+		if (pullDistance >= THRESHOLD) {
+			refreshing = true;
+			pullDistance = 50; // hold spinner visible
+			try {
+				await onrefresh();
+			} finally {
+				refreshing = false;
+				pullDistance = 0;
+			}
+		} else {
+			pullDistance = 0;
+		}
+	}
+
+	const progress = $derived(Math.min(pullDistance / THRESHOLD, 1));
+	const spinnerOpacity = $derived(refreshing ? 1 : progress);
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	bind:this={containerEl}
+	class="relative h-full overflow-y-auto"
+	ontouchstart={onTouchStart}
+	ontouchmove={onTouchMove}
+	ontouchend={onTouchEnd}
+>
+	<!-- Pull indicator -->
+	{#if pullDistance > 0 || refreshing}
+		<div
+			class="flex items-center justify-center transition-opacity"
+			style="height: {pullDistance}px; opacity: {spinnerOpacity}"
+		>
+			<RefreshCw
+				size={18}
+				class="text-muted-foreground {refreshing ? 'animate-spin' : ''}"
+				style="transform: rotate({progress * 360}deg)"
+			/>
+		</div>
+	{/if}
+
+	{@render children()}
+</div>

--- a/src/lib/components/TaskBoard.svelte
+++ b/src/lib/components/TaskBoard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ChevronDown, Plus } from 'lucide-svelte';
-	import { dndzone } from 'svelte-dnd-action';
+	import { dragHandleZone, dragHandle } from 'svelte-dnd-action';
 	import type { Task } from '$lib/types/oracle-task.js';
 	import TaskRow from './TaskRow.svelte';
 	import TaskDetail from './TaskDetail.svelte';
@@ -186,7 +186,7 @@
 					{#if !isCollapsed(section.name)}
 						<ul
 							class="flex flex-col divide-y divide-border overflow-hidden rounded-lg border border-border"
-							use:dndzone={{
+							use:dragHandleZone={{
 								items: section.tasks,
 								flipDurationMs: FLIP_MS,
 								type: sectionType(section.name),
@@ -197,7 +197,7 @@
 						>
 							{#each section.tasks as task (task.id)}
 								<li>
-									<TaskRow {task} {slug} onpatch={handleTaskPatch} onopen={openDetail} />
+									<TaskRow {task} {slug} {dragHandle} onpatch={handleTaskPatch} onopen={openDetail} />
 								</li>
 							{/each}
 						</ul>

--- a/src/lib/components/TaskBoard.svelte
+++ b/src/lib/components/TaskBoard.svelte
@@ -34,46 +34,44 @@
 	type Section = { name: string | null; tasks: Task[] };
 
 	function buildSections(taskList: Task[]): Section[] {
-		const sectionOrder: (string | null)[] = [];
 		const map = new Map<string | null, Task[]>();
 
 		for (const task of taskList) {
 			const key = task.section ?? null;
-			if (!map.has(key)) {
-				sectionOrder.push(key);
-				map.set(key, []);
-			}
+			if (!map.has(key)) map.set(key, []);
 			map.get(key)!.push(task);
 		}
 
-		// Named sections first, then the null/unsectioned group at the end
-		const named: Section[] = [];
-		let unsectioned: Section | null = null;
-
-		for (const name of sectionOrder) {
-			const section: Section = { name, tasks: map.get(name)! };
-			if (name === null) {
-				unsectioned = section;
-			} else {
-				named.push(section);
-			}
-		}
-
-		return unsectioned ? [...named, unsectioned] : named;
+		// Sort sections deterministically by name (numeric-aware so
+		// "Phase 0" < "Phase 1" < "Phase 2" etc.). Null/unsectioned last.
+		return [...map.entries()]
+			.map(([name, tasks]) => ({ name, tasks }))
+			.sort((a, b) => {
+				if (a.name === null) return 1;
+				if (b.name === null) return -1;
+				return a.name.localeCompare(b.name, undefined, { numeric: true });
+			});
 	}
 
 	const sections = $derived(buildSections(localTasks));
 
 	// ── Collapsible sections ───────────────────────────────────────────────────
+	// Plain object instead of Map — Svelte 5's proxy-based reactivity
+	// reliably tracks property access/mutation on plain objects.
 
-	const collapsed = $state(new Map<string | null, boolean>());
+	let collapsed: Record<string, boolean> = $state({});
+
+	function collapseKey(name: string | null): string {
+		return name ?? '__unsectioned__';
+	}
 
 	function toggleSection(name: string | null) {
-		collapsed.set(name, !collapsed.get(name));
+		const key = collapseKey(name);
+		collapsed[key] = !collapsed[key];
 	}
 
 	function isCollapsed(name: string | null): boolean {
-		return collapsed.get(name) ?? false;
+		return collapsed[collapseKey(name)] ?? false;
 	}
 
 	// ── Optimistic patch from TaskRow ──────────────────────────────────────────

--- a/src/lib/components/TaskRow.svelte
+++ b/src/lib/components/TaskRow.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
 	import { GripVertical, GitBranch, CheckCircle2 } from 'lucide-svelte';
+	import type { Action } from 'svelte/action';
 	import type { Task, TaskStatus, TaskAssignee } from '$lib/types/oracle-task.js';
 
 	interface Props {
 		task: Task;
 		slug: string;
+		/** svelte-dnd-action dragHandle action — restricts drag to the grip icon */
+		dragHandle?: Action;
 		/** Optimistic-update callback so the parent can track mutations */
 		onpatch?: (id: string, patch: Partial<Task>) => void;
 		/** Called when the user taps the task content to open the detail sheet */
 		onopen?: (task: Task) => void;
 	}
 
-	const { task, slug, onpatch, onopen }: Props = $props();
+	const { task, slug, dragHandle, onpatch, onopen }: Props = $props();
 
 	// ── Status helpers ────────────────────────────────────────────────────────
 
@@ -239,14 +242,25 @@
 		class="relative flex items-center gap-2 bg-card px-3 py-3 transition-transform"
 		style="transform: translateX({swipeOffsetX}px)"
 	>
-		<!-- Drag handle — touch-none restricts touch-drag to this element on mobile -->
-		<span
-			class="touch-none flex-shrink-0 cursor-grab p-0.5 text-muted-foreground/40 transition-colors hover:text-muted-foreground active:cursor-grabbing"
-			aria-label="Drag to reorder"
-			role="img"
-		>
-			<GripVertical size={14} />
-		</span>
+		<!-- Drag handle — only this element initiates drag (dragHandleZone) -->
+		{#if dragHandle}
+			<span
+				use:dragHandle
+				class="touch-none flex-shrink-0 cursor-grab p-1 text-muted-foreground/40 transition-colors hover:text-muted-foreground active:cursor-grabbing"
+				aria-label="Drag to reorder"
+				role="img"
+			>
+				<GripVertical size={14} />
+			</span>
+		{:else}
+			<span
+				class="touch-none flex-shrink-0 cursor-grab p-1 text-muted-foreground/40 transition-colors hover:text-muted-foreground active:cursor-grabbing"
+				aria-label="Drag to reorder"
+				role="img"
+			>
+				<GripVertical size={14} />
+			</span>
+		{/if}
 
 		<!-- Status pill — tap to cycle -->
 		<button

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import type { PageData } from './$types.js';
 	import { page } from '$app/stores';
+	import { invalidate } from '$app/navigation';
 	import ProjectChats from '$lib/components/ProjectChats.svelte';
+	import PullToRefresh from '$lib/components/PullToRefresh.svelte';
 
 	const { data }: { data: PageData } = $props();
 
@@ -13,6 +15,10 @@
 	// browser back/forward buttons work. The layout highlights the active tab
 	// using the same param. Defaults to 'chats' (Loom #32).
 	const view = $derived($page.url.searchParams.get('view') ?? 'chats');
+
+	async function refreshProject() {
+		await invalidate(`oracle:project:${fm.slug}`);
+	}
 </script>
 
 {#if view === 'chats'}
@@ -37,9 +43,11 @@
 {:else if view === 'sow'}
 	<!-- SOW tab — Loom #31: leading H1 hidden via prose modifier to avoid a
 	     duplicate page title (the layout header already shows fm.title). -->
-	<div class="p-6" data-testid="sow-content">
-		<article class="prose [&>h1:first-child]:hidden">
-			{@html project.bodyHtml}
-		</article>
-	</div>
+	<PullToRefresh onrefresh={refreshProject}>
+		<div class="p-6" data-testid="sow-content">
+			<article class="prose [&>h1:first-child]:hidden">
+				{@html project.bodyHtml}
+			</article>
+		</div>
+	</PullToRefresh>
 {/if}

--- a/src/routes/projects/[slug]/tasks/+page.svelte
+++ b/src/routes/projects/[slug]/tasks/+page.svelte
@@ -3,10 +3,15 @@
 	import { invalidate } from '$app/navigation';
 	import type { PageData } from './$types.js';
 	import TaskBoard from '$lib/components/TaskBoard.svelte';
+	import PullToRefresh from '$lib/components/PullToRefresh.svelte';
 
 	const { data }: { data: PageData } = $props();
 
 	const slug = data.project.frontmatter.slug;
+
+	async function refresh() {
+		await invalidate(`oracle:tasks:${slug}`);
+	}
 
 	onMount(() => {
 		const es = new EventSource('/api/events');
@@ -30,8 +35,10 @@
 	});
 </script>
 
-<TaskBoard
-	tasks={data.tasks}
-	slug={data.project.frontmatter.slug}
-	githubRepo={data.project.frontmatter.platform_ids?.github_repo}
-/>
+<PullToRefresh onrefresh={refresh}>
+	<TaskBoard
+		tasks={data.tasks}
+		slug={data.project.frontmatter.slug}
+		githubRepo={data.project.frontmatter.platform_ids?.github_repo}
+	/>
+</PullToRefresh>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { Sun, Moon } from 'lucide-svelte';
+	import { Sun, Moon, Bell, BellOff } from 'lucide-svelte';
+	import { isPushSupported, isPushGranted, subscribePush } from '$lib/push.js';
 
 	// Read version from package.json — injected at build time
 	const version = __APP_VERSION__;
@@ -8,8 +9,16 @@
 
 	let isDark = $state(false);
 
+	// ── Push notification state ───────────────────────────────────────────────
+	let pushSupported = $state(false);
+	let pushEnabled = $state(false);
+	let pushSubscribing = $state(false);
+	let pushError = $state<string | null>(null);
+
 	onMount(() => {
 		isDark = document.documentElement.classList.contains('dark');
+		pushSupported = isPushSupported();
+		pushEnabled = isPushGranted();
 	});
 
 	function toggleTheme() {
@@ -20,6 +29,19 @@
 		} else {
 			document.documentElement.classList.remove('dark');
 			localStorage.setItem('oracle:theme', 'light');
+		}
+	}
+
+	async function enablePush() {
+		pushSubscribing = true;
+		pushError = null;
+		try {
+			await subscribePush();
+			pushEnabled = true;
+		} catch (err) {
+			pushError = (err as Error).message;
+		} finally {
+			pushSubscribing = false;
 		}
 	}
 </script>
@@ -48,6 +70,50 @@
 					<Moon size={18} />
 				{/if}
 			</button>
+		</div>
+	</section>
+
+	<section class="mb-8">
+		<h2 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+			[NOTIFICATIONS]
+		</h2>
+		<div class="p-4 rounded-lg border border-border bg-card">
+			{#if pushEnabled}
+				<div class="flex items-center justify-between">
+					<div>
+						<p class="text-sm font-medium">Push notifications</p>
+						<p class="text-xs text-muted-foreground mt-0.5">Enabled — you'll get alerts when Alfred replies</p>
+					</div>
+					<Bell size={18} class="text-primary" />
+				</div>
+			{:else if pushSupported}
+				<div class="flex items-center justify-between">
+					<div>
+						<p class="text-sm font-medium">Push notifications</p>
+						<p class="text-xs text-muted-foreground mt-0.5">Get notified when Alfred replies</p>
+					</div>
+					<button
+						onclick={enablePush}
+						disabled={pushSubscribing}
+						class="px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-xs font-medium disabled:opacity-50 transition-opacity hover:opacity-90"
+					>
+						{pushSubscribing ? 'Enabling...' : 'Enable'}
+					</button>
+				</div>
+				{#if pushError}
+					<p class="text-xs text-destructive mt-2">{pushError}</p>
+				{/if}
+			{:else}
+				<div class="flex items-center justify-between">
+					<div>
+						<p class="text-sm font-medium">Push notifications</p>
+						<p class="text-xs text-muted-foreground mt-0.5">
+							Not available — open Oracle as an installed PWA to enable
+						</p>
+					</div>
+					<BellOff size={18} class="text-muted-foreground" />
+				</div>
+			{/if}
 		</div>
 	</section>
 


### PR DESCRIPTION
## Summary
- **Section collapse broken**: Replaced `$state(new Map())` with plain reactive object — Svelte 5's proxy-based reactivity doesn't reliably detect Map mutations
- **Drag-and-drop resets section order**: `handleConsider` was appending section tasks at the end of the array, causing `buildSections` (which used insertion order) to move the section to the bottom. Now sections sort deterministically by name with numeric-aware `localeCompare`
- **No way to enable push notifications**: Added push toggle to Settings page with three states: enabled, available (with Enable button), and not available (with PWA install hint)

## Test plan
- [ ] Open task board → tap phase chevron → section should collapse/expand
- [ ] Drag a task within a section → section order should stay fixed
- [ ] Go to Settings → Notifications section should show push toggle
- [ ] On PWA: tap Enable → should prompt for notification permission
- [ ] On browser: should show "Not available — open as installed PWA"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced push notification support in Settings page with a dedicated section. Users can enable notifications, view current status, and see availability indicators.

* **Refactor**
  * Enhanced internal component organization and state management for section ordering and collapse functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->