### PR TITLE
fix: iOS push notification standalone detection

### DIFF
--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -9,11 +9,12 @@
 /** Check if push is supported and the app is installed as PWA */
 export function isPushSupported(): boolean {
 	if (typeof window === 'undefined') return false;
-	return (
-		'serviceWorker' in navigator &&
-		'PushManager' in window &&
-		window.matchMedia('(display-mode: standalone)').matches
-	);
+	// iOS Safari uses navigator.standalone (non-standard) instead of the
+	// display-mode: standalone media query. Check both.
+	const isStandalone =
+		window.matchMedia('(display-mode: standalone)').matches ||
+		(navigator as unknown as { standalone?: boolean }).standalone === true;
+	return 'serviceWorker' in navigator && 'PushManager' in window && isStandalone;
 }
 
 /** Check if push permission has already been granted */


### PR DESCRIPTION
## Summary
- iOS Safari PWAs use `navigator.standalone` (non-standard) instead of the `display-mode: standalone` media query
- `isPushSupported()` now checks both, so the Enable button appears on iOS PWAs
- Same pattern already used in `IOSInstallPrompt.svelte`

## Test plan
- [ ] Open Oracle PWA on iPhone → Settings → Notifications should show Enable button (not "Not available")
- [ ] Tap Enable → iOS permission prompt appears → grant → push works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification detection for iOS Safari and other PWA environments, ensuring the system more accurately recognizes push notification support across a broader range of devices and browser configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->