### PR TITLE
feat(forge): Three glazier tasks covering the surgical three-fix patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- Chat composer is no longer hidden below the fold when opening a thread on iOS Safari PWA — replaced `h-[100dvh]` with `h-full` on the chat page root so the layout fits inside its actual slot rather than overflowing the parent containers.
+- Composer stays visible and focusable after sending a message on iOS Safari PWA — replaced bare `focus()` calls with `focus({ preventScroll: true })` + `scrollIntoView({ block: 'end', behavior: 'instant' })` in both the thread page (`+page.svelte`) and the `ProjectChats` component.
+
+### Added
+
+- Playwright `mobile-webkit-iphone15pro` device project added to `playwright.config.ts` for mobile viewport testing.
+- E2E tests `ISC-13` and `ISC-14` (`tests/e2e/chat-composer-viewport.spec.ts`) assert that the chat composer is visible on thread open and after send at iPhone 15 Pro viewport dimensions.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
 	webServer: {
@@ -15,6 +16,12 @@ const config: PlaywrightTestConfig = {
 		{
 			name: 'chromium',
 			use: { browserName: 'chromium' }
+		},
+		{
+			name: 'mobile-webkit-iphone15pro',
+			use: {
+				...devices['iPhone 15 Pro']
+			}
 		}
 	]
 };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,6 +19,7 @@ const config: PlaywrightTestConfig = {
 		},
 		{
 			name: 'mobile-webkit-iphone15pro',
+			testMatch: '**/chat-composer-viewport.spec.ts',
 			use: {
 				...devices['iPhone 15 Pro']
 			}

--- a/src/lib/components/ProjectChats.svelte
+++ b/src/lib/components/ProjectChats.svelte
@@ -410,7 +410,8 @@
 				await tick();
 				messageInputEl?.focus({ preventScroll: true });
 				messageInputEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
-				if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
+				if (messagesContainerEl && isScrolledToBottom)
+					messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 				reconcileMessages(threadId);
 
 				// Show push prompt after first successful chat response
@@ -468,7 +469,8 @@
 				await tick();
 				messageInputEl?.focus({ preventScroll: true });
 				messageInputEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
-				if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
+				if (messagesContainerEl && isScrolledToBottom)
+					messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 				reconcileMessages(threadId);
 			}
 		} catch (err) {

--- a/src/lib/components/ProjectChats.svelte
+++ b/src/lib/components/ProjectChats.svelte
@@ -253,7 +253,9 @@
 			messagesError = null;
 			threadsError = null;
 			await tick();
-			messageInputEl?.focus();
+			messageInputEl?.focus({ preventScroll: true });
+			messageInputEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
+			if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 		} catch (err) {
 			threadsError = (err as Error).message;
 		}
@@ -406,7 +408,9 @@
 			if (activeThreadId === threadId) {
 				streamingMessageId = null;
 				await tick();
-				messageInputEl?.focus();
+				messageInputEl?.focus({ preventScroll: true });
+				messageInputEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
+				if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 				reconcileMessages(threadId);
 
 				// Show push prompt after first successful chat response
@@ -462,7 +466,9 @@
 				};
 				messages = [...messages, assistantMessage];
 				await tick();
-				messageInputEl?.focus();
+				messageInputEl?.focus({ preventScroll: true });
+				messageInputEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
+				if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 				reconcileMessages(threadId);
 			}
 		} catch (err) {

--- a/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
@@ -283,7 +283,9 @@
 
 			streamingMessageId = null;
 			await tick();
-			textareaEl?.focus();
+			textareaEl?.focus({ preventScroll: true });
+			textareaEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
+			if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 			reconcileMessages(threadId);
 
 			// Show push prompt after first successful chat response
@@ -332,7 +334,9 @@
 			};
 			messages = [...messages, assistantMessage];
 			await tick();
-			textareaEl?.focus();
+			textareaEl?.focus({ preventScroll: true });
+			textareaEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
+			if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 			reconcileMessages(threadId);
 		} catch (err) {
 			messages = messages.filter((m) => m.id !== optimisticId);
@@ -481,7 +485,7 @@
 	}
 </script>
 
-<div class="flex flex-col h-[100dvh] md:h-full" data-testid="mobile-chat-page" data-chat-thread>
+<div class="flex flex-col h-full" data-testid="mobile-chat-page" data-chat-thread>
 	<!-- ── Chat Header (AC-18) — safe-area-inset-top for standalone PWA ── -->
 	<header
 		class="flex items-center gap-1 px-1 py-1 border-b border-border flex-shrink-0 bg-card min-h-[52px]"

--- a/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
@@ -285,7 +285,8 @@
 			await tick();
 			textareaEl?.focus({ preventScroll: true });
 			textareaEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
-			if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
+			if (messagesContainerEl && isScrolledToBottom)
+				messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 			reconcileMessages(threadId);
 
 			// Show push prompt after first successful chat response
@@ -336,7 +337,8 @@
 			await tick();
 			textareaEl?.focus({ preventScroll: true });
 			textareaEl?.scrollIntoView({ block: 'end', behavior: 'instant' });
-			if (messagesContainerEl) messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
+			if (messagesContainerEl && isScrolledToBottom)
+				messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
 			reconcileMessages(threadId);
 		} catch (err) {
 			messages = messages.filter((m) => m.id !== optimisticId);

--- a/tests/e2e/chat-composer-viewport.spec.ts
+++ b/tests/e2e/chat-composer-viewport.spec.ts
@@ -14,18 +14,6 @@ import { test, expect, devices } from '@playwright/test';
 const SLUG = 'test-project';
 const THREADS_API = `/api/projects/${SLUG}/threads`;
 
-/** Returns true when the Pennyworth proxy API is reachable. */
-async function pennyworthReachable(
-	req: import('@playwright/test').APIRequestContext
-): Promise<boolean> {
-	try {
-		const res = await req.get(THREADS_API);
-		return res.status() !== 503 && res.status() !== 404;
-	} catch {
-		return false;
-	}
-}
-
 test.describe('Chat composer viewport (ISC-13, ISC-14)', () => {
 	test.use(devices['iPhone 15 Pro']);
 	test.describe.configure({ mode: 'serial' });
@@ -34,17 +22,16 @@ test.describe('Chat composer viewport (ISC-13, ISC-14)', () => {
 	let available = false;
 
 	test.beforeAll(async ({ request }) => {
-		available = await pennyworthReachable(request);
-		if (!available) return;
+		// Create an ephemeral thread; a 503 response means Pennyworth is not
+		// configured, so we mark the suite unavailable and skip gracefully.
+		const res = await request
+			.post(THREADS_API, { data: { title: `e2e-viewport-${Date.now()}` } })
+			.catch(() => null);
 
-		// Create an ephemeral thread for the test run.
-		const res = await request.post(THREADS_API, {
-			data: { title: `e2e-viewport-${Date.now()}` }
-		});
-		if (res.ok()) {
-			const body = await res.json();
-			threadId = (body.thread?.id ?? body.id ?? null) as string | null;
-		}
+		if (!res || !res.ok()) return;
+		available = true;
+		const body = await res.json();
+		threadId = (body.conversation?.id ?? null) as string | null;
 	});
 
 	test.afterAll(async ({ request }) => {
@@ -82,9 +69,10 @@ test.describe('Chat composer viewport (ISC-13, ISC-14)', () => {
 		const box = await composer.boundingBox();
 
 		expect(box, 'Composer must have a bounding box').not.toBeNull();
-		expect(box!.y + box!.height, 'Composer bottom must be within viewport height').toBeLessThanOrEqual(
-			viewport!.height
-		);
+		expect(
+			box!.y + box!.height,
+			'Composer bottom must be within viewport height'
+		).toBeLessThanOrEqual(viewport!.height);
 	});
 
 	// ── ISC-14: composer remains visible after sending a message ─────────────

--- a/tests/e2e/chat-composer-viewport.spec.ts
+++ b/tests/e2e/chat-composer-viewport.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * E2E viewport tests for chat composer visibility on iPhone 15 Pro.
+ *
+ * ISC-13: Opening a chat thread shows the composer without manual scroll.
+ * ISC-14: After sending a message the composer is still visible.
+ *
+ * These tests require Pennyworth to be reachable (the server-side loader
+ * redirects to the project page when Pennyworth is unavailable). They skip
+ * gracefully when PENNYWORTH_BASE_URL is not configured in the test env.
+ */
+
+import { test, expect, devices } from '@playwright/test';
+
+const SLUG = 'test-project';
+const THREADS_API = `/api/projects/${SLUG}/threads`;
+
+/** Returns true when the Pennyworth proxy API is reachable. */
+async function pennyworthReachable(
+	req: import('@playwright/test').APIRequestContext
+): Promise<boolean> {
+	try {
+		const res = await req.get(THREADS_API);
+		return res.status() !== 503 && res.status() !== 404;
+	} catch {
+		return false;
+	}
+}
+
+test.describe('Chat composer viewport (ISC-13, ISC-14)', () => {
+	test.use(devices['iPhone 15 Pro']);
+	test.describe.configure({ mode: 'serial' });
+
+	let threadId: string | null = null;
+	let available = false;
+
+	test.beforeAll(async ({ request }) => {
+		available = await pennyworthReachable(request);
+		if (!available) return;
+
+		// Create an ephemeral thread for the test run.
+		const res = await request.post(THREADS_API, {
+			data: { title: `e2e-viewport-${Date.now()}` }
+		});
+		if (res.ok()) {
+			const body = await res.json();
+			threadId = (body.thread?.id ?? body.id ?? null) as string | null;
+		}
+	});
+
+	test.afterAll(async ({ request }) => {
+		if (threadId) {
+			await request.delete(`${THREADS_API}/${threadId}`).catch(() => {});
+			threadId = null;
+		}
+	});
+
+	// ── ISC-13: composer is visible on open without scrolling ────────────────
+
+	test('ISC-13: composer is visible when the thread opens', async ({ page }) => {
+		test.skip(!available, 'Pennyworth not reachable — skipping viewport tests');
+		test.skip(!threadId, 'Thread creation failed — skipping');
+
+		await page.goto(`/projects/${SLUG}/chats/${threadId}`);
+
+		// Redirect to /login means auth is active with no test credentials.
+		if (page.url().includes('/login')) {
+			test.skip(true, 'Auth is active — no test credentials configured');
+			return;
+		}
+
+		// Redirect back to the project list means Pennyworth rejected the thread.
+		if (!page.url().includes('/chats/')) {
+			test.skip(true, 'Thread route redirected — Pennyworth rejected the thread ID');
+			return;
+		}
+
+		const composer = page.locator('[data-testid="composer"]');
+		await expect(composer).toBeVisible();
+
+		// Assert the composer is inside the visible viewport without scrolling.
+		const viewport = page.viewportSize();
+		const box = await composer.boundingBox();
+
+		expect(box, 'Composer must have a bounding box').not.toBeNull();
+		expect(box!.y + box!.height, 'Composer bottom must be within viewport height').toBeLessThanOrEqual(
+			viewport!.height
+		);
+	});
+
+	// ── ISC-14: composer remains visible after sending a message ─────────────
+
+	test('ISC-14: composer stays visible after sending a message', async ({ page }) => {
+		test.skip(!available, 'Pennyworth not reachable — skipping viewport tests');
+		test.skip(!threadId, 'Thread creation failed — skipping');
+
+		await page.goto(`/projects/${SLUG}/chats/${threadId}`);
+
+		if (page.url().includes('/login')) {
+			test.skip(true, 'Auth is active — no test credentials configured');
+			return;
+		}
+
+		if (!page.url().includes('/chats/')) {
+			test.skip(true, 'Thread route redirected — Pennyworth rejected the thread ID');
+			return;
+		}
+
+		const composer = page.locator('[data-testid="composer"]');
+		await expect(composer).toBeVisible();
+
+		// Type and send a test message.
+		const textarea = composer.locator('textarea');
+		await textarea.fill('e2e viewport test message');
+
+		const sendBtn = composer.locator('button[type="submit"], button[aria-label*="Send"]');
+		await sendBtn.click();
+
+		// Allow the optimistic message to appear and the compose to reset.
+		await page.waitForTimeout(500);
+
+		// Composer must still be visible after the send.
+		await expect(composer).toBeVisible();
+
+		const viewport = page.viewportSize();
+		const box = await composer.boundingBox();
+
+		expect(box, 'Composer must have a bounding box after send').not.toBeNull();
+		expect(
+			box!.y + box!.height,
+			'Composer bottom must be within viewport height after send'
+		).toBeLessThanOrEqual(viewport!.height);
+	});
+});


### PR DESCRIPTION
## Summary
Three glazier tasks covering the surgical three-fix patch (h-full height, scrollIntoView on send in both chat page and ProjectChats) plus new iPhone-viewport Playwright tests asserting composer visibility on thread open and after send.

Built by the AptoForge Build Council under routing v2 (Foreman plans, Mason executes).

Job: `pAAX2FNxhr0p`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat composer focus and automatic scroll positioning when sending messages and creating conversation threads
  * Improved mobile chat interface viewport behavior and layout responsiveness

* **Tests**
  * Added mobile-specific end-to-end tests to validate chat composer visibility and behavior on mobile device viewports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->