### PR TITLE
fix(header): responsive title size + 2-line clamp on mobile

### DIFF
--- a/src/routes/projects/[slug]/+layout.svelte
+++ b/src/routes/projects/[slug]/+layout.svelte
@@ -36,13 +36,17 @@
 		class="px-6 pb-4 border-b border-border flex-shrink-0"
 		style="padding-top: calc(env(safe-area-inset-top, 0px) + 1rem); margin-top: calc(-1 * env(safe-area-inset-top, 0px));"
 	>
-		<!-- Title row: back arrow + full-width title (no truncation on narrow viewports) -->
-		<div class="flex items-center gap-3">
+		<!-- Title row: back arrow + title. Responsive size to keep the header compact
+		     on mobile viewports; line-clamp-2 so long titles don't push the rest of
+		     the header off-screen. -->
+		<div class="flex items-center gap-3 min-w-0">
 			<a
 				href="/projects"
 				class="md:hidden text-muted-foreground hover:text-foreground flex-shrink-0">←</a
 			>
-			<h1 class="text-[28px] font-bold leading-tight">{fm.title}</h1>
+			<h1 class="text-lg md:text-[28px] font-bold leading-tight line-clamp-2 min-w-0">
+				{fm.title}
+			</h1>
 		</div>
 		<!-- Badge row: right-aligned, stacked below the fixed notification bell -->
 		<div class="flex justify-end mt-1">


### PR DESCRIPTION
## Summary

Fix for a regression in PR #14 — project title was eating 3+ lines on mobile for long project names (Nick reported on \`PAI Orchestration v1 — Unified Operating System\`).

## Change

\`src/routes/projects/[slug]/+layout.svelte\`

\`\`\`diff
- <h1 class="text-[28px] font-bold leading-tight">{fm.title}</h1>
+ <h1 class="text-lg md:text-[28px] font-bold leading-tight line-clamp-2 min-w-0">
+   {fm.title}
+ </h1>
\`\`\`

- \`text-lg\` (18px) on mobile, \`text-[28px]\` on md+ desktop
- \`line-clamp-2\` caps long titles at 2 lines with ellipsis overflow
- \`min-w-0\` on the h1 + wrapper so flex doesn't keep the h1 at its intrinsic content width

## Why not just restore \`truncate\`?

The original complaint that led to PR #14 was "all I can see is like 7 characters." Keeping the title single-line + truncated is worse than allowing 2 lines at a smaller font. 2 lines of 18px fits the same vertical space as 1 line of 28px, and shows more of the title.

## Verification

- \`bun run build\` — ✅ succeeds, client output populated
- \`bun run lint\` — ✅ passes
- \`bun run test:unit\` — runs (not re-verified locally this iteration; previous green on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)