### PR TITLE
fix(chat): render mobile layout on iOS PWA via server-side UA detection

### DIFF
--- a/src/lib/components/ProjectChats.svelte
+++ b/src/lib/components/ProjectChats.svelte
@@ -34,7 +34,7 @@
 <script lang="ts">
 	import { tick } from 'svelte';
 	import { goto, preloadData } from '$app/navigation';
-	import { browser } from '$app/environment';
+	import { page } from '$app/stores';
 	import { ChevronDown } from 'lucide-svelte';
 	import type { Thread, Message } from '$lib/types/chat.js';
 	import { renderChatMarkdown } from '$lib/chat-markdown.js';
@@ -49,6 +49,14 @@
 		apiBasePath?: string;
 		/** Route prefix for mobile chat navigation — defaults to 'projects'. */
 		routePrefix?: string;
+		/**
+		 * Whether to render the mobile thread list layout (true) or the
+		 * desktop two-panel layout (false). Usually sourced from
+		 * `$page.data.isMobile` which is set server-side from the
+		 * User-Agent header. See the comment on the `isMobile` derived
+		 * below for the rationale (iOS PWA hydration bug).
+		 */
+		isMobile?: boolean;
 	};
 
 	const props: Props = $props();
@@ -136,23 +144,27 @@
 
 	// ─── mobile breakpoint (Phase 2.B.4) ─────────────────────────────────────
 	//
-	// Starts false on server and updates after hydration. The parent route wraps
-	// this component in {#key fm.slug}, so isMobile re-evaluates on every
-	// project mount. matchMedia is cheaper than `hidden md:block` because it
-	// controls which component tree is mounted, not just CSS visibility.
-
-	let isMobile = $state(false);
-
-	$effect(() => {
-		if (!browser) return;
-		const mq = window.matchMedia('(max-width: 767px)');
-		isMobile = mq.matches;
-		const handler = (e: MediaQueryListEvent) => {
-			isMobile = e.matches;
-		};
-		mq.addEventListener('change', handler);
-		return () => mq.removeEventListener('change', handler);
-	});
+	// Sourced from `$page.data.isMobile` which is detected server-side via the
+	// User-Agent header in `src/routes/+layout.server.ts`. This replaces the
+	// prior matchMedia + $effect approach which failed on iOS standalone PWA
+	// (see feedback_ios_pwa_hydration.md — Svelte 5 lifecycle hooks do not
+	// reliably fire after hydration in that runtime). UA detection happens
+	// before any render, so the SSR HTML already contains the correct layout
+	// and hydration is a no-op for this decision.
+	//
+	// Tablet fallback: UA detection is intentionally conservative and only
+	// flips true for phones. A user resizing a desktop browser narrower than
+	// 768px will stay on the desktop two-panel layout — acceptable, since the
+	// primary motivation is the iOS PWA bug, not responsive resizing.
+	//
+	// Precedence: explicit `isMobile` prop (tests + integration use this) wins,
+	// otherwise fall back to `$page.data.isMobile` (the production default,
+	// set in src/routes/+layout.server.ts). $page.data can be undefined in
+	// component-level tests that don't mount the route tree; fall back to
+	// false (desktop layout) in that case to preserve prior test behavior.
+	const isMobile = $derived(
+		props.isMobile !== undefined ? props.isMobile : $page?.data?.isMobile === true
+	);
 
 	// Ref for the mobile thread list scroll container
 	let mobileThreadListEl = $state<HTMLElement | null>(null);

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -3,7 +3,23 @@ import { redirect } from '@sveltejs/kit';
 import { readAllProjects, readAllAreas } from '$lib/server/oracle-reader.js';
 import { COOKIE_NAME, validateSessionToken } from '$lib/server/auth.js';
 
-export const load: LayoutServerLoad = async ({ depends, cookies, url }) => {
+/**
+ * User-Agent based mobile detection. Used to render the correct chat layout
+ * at SSR time so we don't depend on client-side $effect / onMount which is
+ * unreliable in the iOS standalone PWA (see feedback_ios_pwa_hydration.md).
+ *
+ * Conservative match: only flip to `true` when the UA clearly indicates a
+ * mobile device. Tablets (iPad, Android tablets) stay on desktop layout —
+ * that matches the prior matchMedia('(max-width: 767px)') behavior.
+ */
+function detectMobileFromUA(userAgent: string): boolean {
+	if (!userAgent) return false;
+	return /iPhone|iPod|Android.*Mobile|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
+}
+
+export const load: LayoutServerLoad = async ({ depends, cookies, url, request }) => {
+	const isMobile = detectMobileFromUA(request.headers.get('user-agent') ?? '');
+
 	// Auth check — redirect to /login if not authenticated
 	// (replaces hooks.server.ts which is incompatible with SvelteKit + Vite 7 PWA builds)
 	const publicPaths = ['/login'];
@@ -21,7 +37,7 @@ export const load: LayoutServerLoad = async ({ depends, cookies, url }) => {
 
 	// Skip sidebar data for public pages (login doesn't need it)
 	if (publicPaths.some((p) => url.pathname === p || url.pathname.startsWith(p + '/'))) {
-		return { projects: [], areas: [] };
+		return { projects: [], areas: [], isMobile };
 	}
 
 	// Register dependencies so SSE-driven invalidate('oracle:projects' | 'oracle:areas')
@@ -29,5 +45,5 @@ export const load: LayoutServerLoad = async ({ depends, cookies, url }) => {
 	depends('oracle:projects');
 	depends('oracle:areas');
 	const [projects, areas] = await Promise.all([readAllProjects(), readAllAreas()]);
-	return { projects, areas };
+	return { projects, areas, isMobile };
 };

--- a/tests/unit/mobile-chat.test.ts
+++ b/tests/unit/mobile-chat.test.ts
@@ -76,7 +76,8 @@ describe('Mobile thread list (ProjectChats in mobile mode)', () => {
 				slug: 'oracle-app',
 				initialThreads: [SAMPLE_PERSISTENT, SAMPLE_EPHEMERAL],
 				initialMessages: [],
-				loaderError: null
+				loaderError: null,
+				isMobile: true
 			}
 		});
 
@@ -93,7 +94,8 @@ describe('Mobile thread list (ProjectChats in mobile mode)', () => {
 				slug: 'oracle-app',
 				initialThreads: [],
 				initialMessages: [],
-				loaderError: null
+				loaderError: null,
+				isMobile: true
 			}
 		});
 
@@ -111,7 +113,8 @@ describe('Mobile thread list (ProjectChats in mobile mode)', () => {
 				slug: 'oracle-app',
 				initialThreads: [SAMPLE_PERSISTENT, SAMPLE_EPHEMERAL],
 				initialMessages: [],
-				loaderError: null
+				loaderError: null,
+				isMobile: true
 			}
 		});
 
@@ -128,7 +131,8 @@ describe('Mobile thread list (ProjectChats in mobile mode)', () => {
 				slug: 'oracle-app',
 				initialThreads: [SAMPLE_PERSISTENT],
 				initialMessages: [],
-				loaderError: null
+				loaderError: null,
+				isMobile: true
 			}
 		});
 
@@ -142,7 +146,8 @@ describe('Mobile thread list (ProjectChats in mobile mode)', () => {
 				slug: 'oracle-app',
 				initialThreads: [SAMPLE_PERSISTENT],
 				initialMessages: [],
-				loaderError: null
+				loaderError: null,
+				isMobile: true
 			}
 		});
 


### PR DESCRIPTION
## Summary

Fix for Nick's 2026-04-24 iPhone PWA screenshot showing the desktop two-panel chat layout (threads list + messages side-by-side, composer off the viewport) on a native iPhone.

## Root cause

`ProjectChats.svelte` used `$effect` with `matchMedia` to toggle `isMobile` after hydration. Per `feedback_ios_pwa_hydration.md`, Svelte 5 lifecycle hooks (`onMount` / `$effect`) do not reliably fire in iOS standalone PWA. `isMobile` stayed at its server-side default of `false` and the desktop layout rendered.

Desktop Safari + Android Chrome both handle `$effect` correctly, which is why only Nick's iPhone PWA exhibited the bug.

## Fix

Detect mobile from the `User-Agent` header in `src/routes/+layout.server.ts` and surface it via `$page.data.isMobile`. The SSR HTML already contains the correct layout — no hydration dependency.

`ProjectChats.svelte` reads `isMobile` from:

1. An explicit `isMobile` prop (for tests + callers that want to override)
2. Otherwise `$page.data.isMobile` (production default from +layout.server.ts)
3. Otherwise `false` (defensive fallback for component tests without page store)

## UA detection

```ts
function detectMobileFromUA(userAgent: string): boolean {
  if (!userAgent) return false;
  return /iPhone|iPod|Android.*Mobile|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
}
```

Intentionally conservative — matches the prior `matchMedia('(max-width: 767px)')` practice of keeping tablets on the desktop layout. A resized desktop browser narrower than 768px also stays on desktop.

## Test changes

`tests/unit/mobile-chat.test.ts` — the jsdom test env has no page store populated, so every `render(...)` call in this file now passes `isMobile: true` explicitly. 80/80 unit tests pass.

## Verification

- `bun run build` ✅
- `bun run lint` ✅
- `bun run test:unit` ✅ 80/80

🤖 Generated with [Claude Code](https://claude.com/claude-code)