### PR TITLE
fix(chat): send button + chat-thread full-screen takeover on iOS PWA

### DIFF
--- a/src/routes/projects/[slug]/+layout.svelte
+++ b/src/routes/projects/[slug]/+layout.svelte
@@ -22,6 +22,14 @@
 					: 'chats'
 	);
 
+	// When we're inside a specific chat thread, the thread page renders a
+	// full-screen takeover with its own header (back arrow + title + overflow
+	// menu) and its own safe-area handling. Suppress this layout's project
+	// title header + tab bar in that case — otherwise they stack above the
+	// thread page's chat header and produce double-headers + weird spacing
+	// (see Nick's 2026-04-24 screenshot before this fix).
+	const inChatThread = $derived(/\/chats\/[^/]+$/.test($page.url.pathname));
+
 	const tabs = $derived([
 		{ id: 'chats', label: 'Chats', href: `/projects/${fm.slug}` },
 		{ id: 'artifacts', label: 'Artifacts', href: `/projects/${fm.slug}?view=artifacts` },
@@ -31,52 +39,54 @@
 </script>
 
 <div class="flex flex-col h-full">
-	<!-- Page header — extends background into safe-area notch band; cancels main's pt-safe-area to avoid double-padding -->
-	<header
-		class="px-6 pb-4 border-b border-border flex-shrink-0"
-		style="padding-top: calc(env(safe-area-inset-top, 0px) + 1rem); margin-top: calc(-1 * env(safe-area-inset-top, 0px));"
-	>
-		<!-- Title row: back arrow + title. Responsive size to keep the header compact
+	{#if !inChatThread}
+		<!-- Page header — extends background into safe-area notch band; cancels main's pt-safe-area to avoid double-padding -->
+		<header
+			class="px-6 pb-4 border-b border-border flex-shrink-0"
+			style="padding-top: calc(env(safe-area-inset-top, 0px) + 1rem); margin-top: calc(-1 * env(safe-area-inset-top, 0px));"
+		>
+			<!-- Title row: back arrow + title. Responsive size to keep the header compact
 		     on mobile viewports; line-clamp-2 so long titles don't push the rest of
 		     the header off-screen. -->
-		<div class="flex items-center gap-3 min-w-0">
-			<a
-				href="/projects"
-				class="md:hidden text-muted-foreground hover:text-foreground flex-shrink-0">←</a
-			>
-			<h1 class="text-lg md:text-[28px] font-bold leading-tight line-clamp-2 min-w-0">
-				{fm.title}
-			</h1>
-		</div>
-		<!-- Badge row: right-aligned, stacked below the fixed notification bell -->
-		<div class="flex justify-end mt-1">
-			<span
-				class="px-2 py-0.5 rounded-full bg-muted text-muted-foreground text-xs font-semibold uppercase"
-			>
-				{fm.state}
-			</span>
-		</div>
-	</header>
+			<div class="flex items-center gap-3 min-w-0">
+				<a
+					href="/projects"
+					class="md:hidden text-muted-foreground hover:text-foreground flex-shrink-0">←</a
+				>
+				<h1 class="text-lg md:text-[28px] font-bold leading-tight line-clamp-2 min-w-0">
+					{fm.title}
+				</h1>
+			</div>
+			<!-- Badge row: right-aligned, stacked below the fixed notification bell -->
+			<div class="flex justify-end mt-1">
+				<span
+					class="px-2 py-0.5 rounded-full bg-muted text-muted-foreground text-xs font-semibold uppercase"
+				>
+					{fm.state}
+				</span>
+			</div>
+		</header>
 
-	<!-- Tab bar -->
-	<nav class="flex border-b border-border px-6 flex-shrink-0" aria-label="Project sections">
-		{#each tabs as tab (tab.id)}
-			<a
-				href={tab.href}
-				class="px-4 py-2.5 text-sm transition-colors relative
+		<!-- Tab bar -->
+		<nav class="flex border-b border-border px-6 flex-shrink-0" aria-label="Project sections">
+			{#each tabs as tab (tab.id)}
+				<a
+					href={tab.href}
+					class="px-4 py-2.5 text-sm transition-colors relative
 					{activeTab === tab.id ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'}"
-				aria-current={activeTab === tab.id ? 'page' : undefined}
-			>
-				{tab.label}
-				{#if activeTab === tab.id}
-					<span
-						class="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-t"
-						aria-hidden="true"
-					></span>
-				{/if}
-			</a>
-		{/each}
-	</nav>
+					aria-current={activeTab === tab.id ? 'page' : undefined}
+				>
+					{tab.label}
+					{#if activeTab === tab.id}
+						<span
+							class="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-t"
+							aria-hidden="true"
+						></span>
+					{/if}
+				</a>
+			{/each}
+		</nav>
+	{/if}
 
 	<!-- Tab content -->
 	<div class="flex-1 overflow-y-auto">

--- a/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
@@ -373,6 +373,13 @@
 	// Auto-grow textarea from 1 to 4 lines (AC-26)
 	function handleTextareaInput(event: Event): void {
 		const el = event.target as HTMLTextAreaElement;
+		// Explicitly mirror the DOM value into the `draft` rune. `bind:value`
+		// already does this on desktop / Android, but in the iOS standalone
+		// PWA the bind doesn't reliably propagate — see
+		// feedback_ios_pwa_hydration.md. Without this line the user can type
+		// into the composer but `draft` stays "", leaving the send button
+		// stuck in its disabled state and making it look unresponsive.
+		draft = el.value;
 		el.style.height = 'auto';
 		// 4 lines × ~24px line-height + 16px vertical padding
 		const maxHeight = 4 * 24 + 16;


### PR DESCRIPTION
## Summary

Three fixes for iOS PWA chat reported in Nick's 2026-04-24 8:49am screenshot after PR #18:

1. **Send button not firing** — explicit `draft = el.value` in `handleTextareaInput` so the composer's \`disabled\` state evaluates correctly on iOS PWA where \`bind:value\` doesn't reliably propagate.
2. **Project title clipping the notch + huge gap below tabs** — hide the project layout's header + tab bar when on a chat thread route. The thread page is the intended full-screen takeover; showing both caused double-chrome + broken safe-area math.

## Verification

- \`bun run build\` ✅
- \`bun run lint\` ✅
- \`bun run test:unit\` ✅ 80/80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate header and tab navigation appearing when viewing chat threads for a cleaner interface
  * Fixed text input synchronization on iOS standalone app, resolving send button becoming stuck in disabled state while typing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->