### PR TITLE
fix(chat): bypass draft-rune reactivity for the send button on iOS PWA

### DIFF
--- a/src/routes/projects/[slug]/+layout.svelte
+++ b/src/routes/projects/[slug]/+layout.svelte
@@ -22,6 +22,14 @@
 					: 'chats'
 	);
 
+	// When we're inside a specific chat thread, the thread page renders a
+	// full-screen takeover with its own header (back arrow + title + overflow
+	// menu) and its own safe-area handling. Suppress this layout's project
+	// title header + tab bar in that case — otherwise they stack above the
+	// thread page's chat header and produce double-headers + weird spacing
+	// (see Nick's 2026-04-24 screenshot before this fix).
+	const inChatThread = $derived(/\/chats\/[^/]+$/.test($page.url.pathname));
+
 	const tabs = $derived([
 		{ id: 'chats', label: 'Chats', href: `/projects/${fm.slug}` },
 		{ id: 'artifacts', label: 'Artifacts', href: `/projects/${fm.slug}?view=artifacts` },
@@ -31,52 +39,54 @@
 </script>
 
 <div class="flex flex-col h-full">
-	<!-- Page header — extends background into safe-area notch band; cancels main's pt-safe-area to avoid double-padding -->
-	<header
-		class="px-6 pb-4 border-b border-border flex-shrink-0"
-		style="padding-top: calc(env(safe-area-inset-top, 0px) + 1rem); margin-top: calc(-1 * env(safe-area-inset-top, 0px));"
-	>
-		<!-- Title row: back arrow + title. Responsive size to keep the header compact
+	{#if !inChatThread}
+		<!-- Page header — extends background into safe-area notch band; cancels main's pt-safe-area to avoid double-padding -->
+		<header
+			class="px-6 pb-4 border-b border-border flex-shrink-0"
+			style="padding-top: calc(env(safe-area-inset-top, 0px) + 1rem); margin-top: calc(-1 * env(safe-area-inset-top, 0px));"
+		>
+			<!-- Title row: back arrow + title. Responsive size to keep the header compact
 		     on mobile viewports; line-clamp-2 so long titles don't push the rest of
 		     the header off-screen. -->
-		<div class="flex items-center gap-3 min-w-0">
-			<a
-				href="/projects"
-				class="md:hidden text-muted-foreground hover:text-foreground flex-shrink-0">←</a
-			>
-			<h1 class="text-lg md:text-[28px] font-bold leading-tight line-clamp-2 min-w-0">
-				{fm.title}
-			</h1>
-		</div>
-		<!-- Badge row: right-aligned, stacked below the fixed notification bell -->
-		<div class="flex justify-end mt-1">
-			<span
-				class="px-2 py-0.5 rounded-full bg-muted text-muted-foreground text-xs font-semibold uppercase"
-			>
-				{fm.state}
-			</span>
-		</div>
-	</header>
+			<div class="flex items-center gap-3 min-w-0">
+				<a
+					href="/projects"
+					class="md:hidden text-muted-foreground hover:text-foreground flex-shrink-0">←</a
+				>
+				<h1 class="text-lg md:text-[28px] font-bold leading-tight line-clamp-2 min-w-0">
+					{fm.title}
+				</h1>
+			</div>
+			<!-- Badge row: right-aligned, stacked below the fixed notification bell -->
+			<div class="flex justify-end mt-1">
+				<span
+					class="px-2 py-0.5 rounded-full bg-muted text-muted-foreground text-xs font-semibold uppercase"
+				>
+					{fm.state}
+				</span>
+			</div>
+		</header>
 
-	<!-- Tab bar -->
-	<nav class="flex border-b border-border px-6 flex-shrink-0" aria-label="Project sections">
-		{#each tabs as tab (tab.id)}
-			<a
-				href={tab.href}
-				class="px-4 py-2.5 text-sm transition-colors relative
+		<!-- Tab bar -->
+		<nav class="flex border-b border-border px-6 flex-shrink-0" aria-label="Project sections">
+			{#each tabs as tab (tab.id)}
+				<a
+					href={tab.href}
+					class="px-4 py-2.5 text-sm transition-colors relative
 					{activeTab === tab.id ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'}"
-				aria-current={activeTab === tab.id ? 'page' : undefined}
-			>
-				{tab.label}
-				{#if activeTab === tab.id}
-					<span
-						class="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-t"
-						aria-hidden="true"
-					></span>
-				{/if}
-			</a>
-		{/each}
-	</nav>
+					aria-current={activeTab === tab.id ? 'page' : undefined}
+				>
+					{tab.label}
+					{#if activeTab === tab.id}
+						<span
+							class="absolute bottom-0 left-0 right-0 h-0.5 bg-primary rounded-t"
+							aria-hidden="true"
+						></span>
+					{/if}
+				</a>
+			{/each}
+		</nav>
+	{/if}
 
 	<!-- Tab content -->
 	<div class="flex-1 overflow-y-auto">

--- a/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
@@ -373,6 +373,13 @@
 	// Auto-grow textarea from 1 to 4 lines (AC-26)
 	function handleTextareaInput(event: Event): void {
 		const el = event.target as HTMLTextAreaElement;
+		// Explicitly mirror the DOM value into the `draft` rune. `bind:value`
+		// already does this on desktop / Android, but in the iOS standalone
+		// PWA the bind doesn't reliably propagate — see
+		// feedback_ios_pwa_hydration.md. Without this line the user can type
+		// into the composer but `draft` stays "", leaving the send button
+		// stuck in its disabled state and making it look unresponsive.
+		draft = el.value;
 		el.style.height = 'auto';
 		// 4 lines × ~24px line-height + 16px vertical padding
 		const maxHeight = 4 * 24 + 16;

--- a/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
@@ -191,7 +191,11 @@
 	}
 
 	async function sendCurrentMessage(): Promise<void> {
-		const text = draft.trim();
+		// Read the textarea directly as a fallback for `draft`. On iOS PWA
+		// bind:value + $state assignments from event handlers do not always
+		// propagate (see feedback_ios_pwa_hydration.md). Pulling straight from
+		// the DOM sidesteps the reactivity layer entirely when it's needed.
+		const text = (textareaEl?.value ?? draft).trim();
 		if (text === '' || sending || !localThread) return;
 
 		const threadId = localThread.id;
@@ -205,9 +209,13 @@
 		};
 
 		messages = [...messages, optimisticMessage];
-		const previousDraft = draft;
+		const previousDraft = textareaEl?.value ?? draft;
 		draft = '';
 		if (textareaEl) {
+			// bind:value may not push '' back to the DOM on iOS PWA — clear
+			// the textarea explicitly so the user sees their message vanish
+			// from the composer after send (feedback_ios_pwa_hydration.md).
+			textareaEl.value = '';
 			textareaEl.style.height = 'auto';
 		}
 		sending = true;
@@ -298,6 +306,7 @@
 			streamingMessageId = null;
 			messages = messages.filter((m) => m.id !== optimisticId && m.id !== assistantId);
 			draft = previousDraft;
+			if (textareaEl) textareaEl.value = previousDraft;
 			sendError = (err as Error).message;
 		} finally {
 			sending = false;
@@ -343,6 +352,7 @@
 		} catch (err) {
 			messages = messages.filter((m) => m.id !== optimisticId);
 			draft = previousDraft;
+			if (textareaEl) textareaEl.value = previousDraft;
 			sendError = (err as Error).message;
 		} finally {
 			sending = false;
@@ -685,11 +695,21 @@
 				data-testid="message-input"
 			></textarea>
 
-			<!-- Send button: 44×44 minimum touch target (AC-27, AC-28) -->
+			<!--
+				Send button: 44×44 minimum touch target (AC-27, AC-28).
+				disabled is gated on `sending` only (not `draft.trim() === ''`)
+				because on iOS PWA, Svelte 5 state assignments from bind:value
+				and event handlers don't always propagate into reactive
+				expressions (see feedback_ios_pwa_hydration.md). Using draft in
+				`disabled` means the button can be stuck in its disabled state
+				even when the textarea has content, and a user tap produces no
+				feedback. The empty-string guard has been moved into
+				sendCurrentMessage() which reads the textarea value directly.
+			-->
 			<button
 				type="button"
 				onclick={() => void sendCurrentMessage()}
-				disabled={sending || draft.trim() === ''}
+				disabled={sending}
 				class="flex items-center justify-center w-11 h-11 min-w-[44px] min-h-[44px] bg-primary text-primary-foreground rounded-2xl disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed transition-colors flex-shrink-0"
 				aria-label="Send message"
 				data-testid="send-button"


### PR DESCRIPTION
Second-attempt fix for the iOS PWA send button. PR #19 explicitly mirrored textarea into draft on oninput but Nick still reported no send action. This PR defensively removes draft-rune from the disabled= binding and reads textareaEl.value directly in sendCurrentMessage + post-send DOM clears. See commit message for full rationale.

Verified: bun run build ✅, bun run lint ✅, bun run test:unit 80/80 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)