### PR TITLE
fix(pwa): format-detection meta + autoUpdate SW registration (Stage 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "app",
 	"private": true,
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,15 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<!--
+			Disable Safari's automatic phone-number / email / address / date
+			detection. When enabled (default), Safari rewrites the DOM BEFORE
+			Svelte hydration runs — which breaks hydration parity, causes
+			SvelteKit to fall back to a client-only re-render, and makes
+			lifecycle hooks (onMount / $effect) look flaky. See
+			github.com/sveltejs/svelte/issues/17357.
+		-->
+		<meta name="format-detection" content="telephone=no, date=no, address=no, email=no" />
 		<meta name="theme-color" content="#0D0F11" />
 		<meta name="description" content="Personal operations system powered by Alfred" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,12 @@ export default defineConfig({
 		SvelteKitPWA({
 			srcDir: 'src',
 			strategies: 'injectManifest',
-			registerType: 'prompt',
+			// `autoUpdate` silently replaces the SW as soon as a new version
+			// is detected, vs `prompt` which requires a user tap. iOS
+			// standalone PWAs can't easily surface that prompt (no reliable
+			// beforeinstallprompt-equivalent) and can get stuck on a broken
+			// old SW indefinitely — see github.com/sveltejs/svelte/issues/12313.
+			registerType: 'autoUpdate',
 			injectManifest: {
 				globPatterns: ['client/**/*.{js,css,ico,png,svg,webp,woff,woff2}']
 			},


### PR DESCRIPTION
## Stage 1 of the chat PWA cleanup

Per three parallel ruthless reviews (researcher + auditor + architect), most of last night's patching was fighting a stale iOS service worker shell, not actual reactivity bugs. Stage 1 = smallest-diff, highest-leverage fixes to test that hypothesis before the bigger refactor.

## Changes

1. **`<meta name="format-detection">` in app.html** — disables Safari auto-detection of phone numbers / emails / addresses / dates, which rewrites the DOM before hydration and breaks SvelteKit hydration parity. Citation: [svelte#17357](https://github.com/sveltejs/svelte/issues/17357).

2. **Bump package.json 0.2.1 → 0.3.0** — vite-pwa derives SW cache names from the version, so installed PWAs will detect + swap to a fresh SW on next open.

3. **registerType: 'prompt' → 'autoUpdate' in vite.config.ts** — silent replacement is the right UX for iOS standalone PWAs that can't reliably surface an update banner. Citation: [svelte#12313](https://github.com/sveltejs/svelte/issues/12313) — stale SW + dynamic imports.

## Verification

- `bun run build` ✅
- `bun run lint` ✅  
- `bun run test:unit` ✅ 80/80
- Meta tag confirmed in SSR response

## After deploy

Nick force-quits the iPhone PWA, reopens → new SW takes over → retest the send button. If it works, we've confirmed the stale-SW theory and Stage 2 can be a pure cleanup/refactor instead of a bug hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.3.0

* **Bug Fixes**
  * Improved Safari browser compatibility to prevent rendering inconsistencies with formatted content

* **New Features**
  * Progressive Web App now automatically installs updates in the background without requiring user confirmation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->