### PR TITLE
feat(projects): render STATUS.md + DECISIONS.md as new tabs

### DIFF
--- a/src/lib/server/oracle-reader.ts
+++ b/src/lib/server/oracle-reader.ts
@@ -31,7 +31,13 @@ import {
 	renderMarkdown,
 	sortByOrder
 } from './markdown.js';
-import type { Project, Area, SidebarItem, DashboardCard } from '$lib/types/oracle.js';
+import type {
+	Project,
+	ProjectDoc,
+	Area,
+	SidebarItem,
+	DashboardCard
+} from '$lib/types/oracle.js';
 import type { Task, TasksFile } from '$lib/types/oracle-task.js';
 
 const VALID_STATUSES = new Set(['backlog', 'ready', 'in_progress', 'review', 'done']);
@@ -123,6 +129,44 @@ export async function readProject(slug: string): Promise<Project | null> {
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Read a sibling project doc file (STATUS.md / DECISIONS.md) from disk.
+ *
+ * Returns null when the file doesn't exist — most projects haven't adopted
+ * the 4-tier doc framework yet, so absence is the common case and not an error.
+ *
+ * Mirrors the security checks from readProject() so URL slugs can't traverse
+ * out of the Projects directory.
+ */
+async function readProjectDoc(slug: string, filename: string): Promise<ProjectDoc | null> {
+	if (!isSafeSlug(slug)) return null;
+	const projectsDir = getProjectsDir();
+	const filePath = join(projectsDir, slug, filename);
+	if (!isPathInside(filePath, projectsDir)) return null;
+	try {
+		const raw = await readFile(filePath, 'utf-8');
+		const bodyHtml = await renderMarkdown(raw);
+		return {
+			bodyMarkdown: raw,
+			bodyHtml,
+			filePath,
+			githubEditUrl: githubEditUrl('Projects', slug, filename)
+		};
+	} catch {
+		return null;
+	}
+}
+
+/** Read STATUS.md for a project. Returns null when the file doesn't exist. */
+export async function readProjectStatus(slug: string): Promise<ProjectDoc | null> {
+	return readProjectDoc(slug, 'STATUS.md');
+}
+
+/** Read DECISIONS.md for a project. Returns null when the file doesn't exist. */
+export async function readProjectDecisions(slug: string): Promise<ProjectDoc | null> {
+	return readProjectDoc(slug, 'DECISIONS.md');
 }
 
 /** Parse a single area from disk */

--- a/src/lib/server/oracle-reader.ts
+++ b/src/lib/server/oracle-reader.ts
@@ -31,13 +31,7 @@ import {
 	renderMarkdown,
 	sortByOrder
 } from './markdown.js';
-import type {
-	Project,
-	ProjectDoc,
-	Area,
-	SidebarItem,
-	DashboardCard
-} from '$lib/types/oracle.js';
+import type { Project, ProjectDoc, Area, SidebarItem, DashboardCard } from '$lib/types/oracle.js';
 import type { Task, TasksFile } from '$lib/types/oracle-task.js';
 
 const VALID_STATUSES = new Set(['backlog', 'ready', 'in_progress', 'review', 'done']);

--- a/src/lib/types/oracle.ts
+++ b/src/lib/types/oracle.ts
@@ -57,6 +57,17 @@ export interface Project {
 	githubEditUrl: string;
 }
 
+/**
+ * Generic project doc — used for sibling files like STATUS.md and DECISIONS.md.
+ * Slimmer than Project: no frontmatter, no DoD parsing — just the rendered body.
+ */
+export interface ProjectDoc {
+	bodyMarkdown: string;
+	bodyHtml: string;
+	filePath: string;
+	githubEditUrl: string;
+}
+
 /** Same for areas */
 export interface Area {
 	frontmatter: AreaFrontmatter;

--- a/src/routes/projects/[slug]/+layout.server.ts
+++ b/src/routes/projects/[slug]/+layout.server.ts
@@ -1,12 +1,22 @@
 import type { LayoutServerLoad } from './$types.js';
-import { readProject } from '$lib/server/oracle-reader.js';
+import {
+	readProject,
+	readProjectStatus,
+	readProjectDecisions
+} from '$lib/server/oracle-reader.js';
 import { error } from '@sveltejs/kit';
 
 export const load: LayoutServerLoad = async ({ params, depends }) => {
 	depends(`oracle:project:${params.slug}`);
-	const project = await readProject(params.slug);
+	const [project, status, decisions] = await Promise.all([
+		readProject(params.slug),
+		readProjectStatus(params.slug),
+		readProjectDecisions(params.slug)
+	]);
 	if (!project) {
 		error(404, `Project "${params.slug}" not found`);
 	}
-	return { project };
+	// status and decisions are nullable — most projects don't have them yet.
+	// Adoption of the 4-tier doc framework is staged per project.
+	return { project, status, decisions };
 };

--- a/src/routes/projects/[slug]/+layout.server.ts
+++ b/src/routes/projects/[slug]/+layout.server.ts
@@ -1,9 +1,5 @@
 import type { LayoutServerLoad } from './$types.js';
-import {
-	readProject,
-	readProjectStatus,
-	readProjectDecisions
-} from '$lib/server/oracle-reader.js';
+import { readProject, readProjectStatus, readProjectDecisions } from '$lib/server/oracle-reader.js';
 import { error } from '@sveltejs/kit';
 
 export const load: LayoutServerLoad = async ({ params, depends }) => {

--- a/src/routes/projects/[slug]/+layout.svelte
+++ b/src/routes/projects/[slug]/+layout.svelte
@@ -12,21 +12,31 @@
 	const project = $derived(data.project);
 	const fm = $derived(project.frontmatter);
 
+	// Tab is driven by the `?view=` search param (or /tasks sub-route). New views
+	// (status, decisions) added 2026-04-25 alongside the 4-tier doc framework.
 	const activeTab = $derived(
 		$page.url.pathname.endsWith('/tasks')
 			? 'tasks'
-			: $page.url.searchParams.get('view') === 'artifacts'
-				? 'artifacts'
-				: $page.url.searchParams.get('view') === 'sow'
-					? 'sow'
-					: 'chats'
+			: ((): string => {
+					const view = $page.url.searchParams.get('view');
+					if (view === 'status') return 'status';
+					if (view === 'decisions') return 'decisions';
+					if (view === 'sow') return 'sow';
+					if (view === 'artifacts') return 'artifacts';
+					return 'chats';
+				})()
 	);
 
+	// Tab order: Chats (default) → Status (read-first per 4-tier framework) → SOW
+	// (slim plan) → Decisions (history) → Tasks → Artifacts. Status + Decisions
+	// always render — empty state explains the framework when files don't exist.
 	const tabs = $derived([
 		{ id: 'chats', label: 'Chats', href: `/projects/${fm.slug}` },
-		{ id: 'artifacts', label: 'Artifacts', href: `/projects/${fm.slug}?view=artifacts` },
+		{ id: 'status', label: 'Status', href: `/projects/${fm.slug}?view=status` },
 		{ id: 'sow', label: 'SOW', href: `/projects/${fm.slug}?view=sow` },
-		{ id: 'tasks', label: 'Tasks', href: `/projects/${fm.slug}/tasks` }
+		{ id: 'decisions', label: 'Decisions', href: `/projects/${fm.slug}?view=decisions` },
+		{ id: 'tasks', label: 'Tasks', href: `/projects/${fm.slug}/tasks` },
+		{ id: 'artifacts', label: 'Artifacts', href: `/projects/${fm.slug}?view=artifacts` }
 	]);
 </script>
 
@@ -66,16 +76,23 @@
 		</div>
 	</header>
 
-	<!-- Tab bar -->
+	<!--
+		Tab bar. 6 tabs overflow the mobile viewport (~327px usable after px-6
+		padding) so the row scrolls horizontally on small screens. Active tab
+		auto-scrolls into view via `scroll-margin-inline`. iOS gets momentum
+		scroll for free.
+	-->
 	<nav
-		class="project-chrome flex border-b border-border px-6 flex-shrink-0"
+		class="project-chrome flex border-b border-border px-6 flex-shrink-0 overflow-x-auto scrollbar-none"
+		style="scroll-padding-inline: 1.5rem;"
 		aria-label="Project sections"
 	>
 		{#each tabs as tab (tab.id)}
 			<a
 				href={tab.href}
-				class="px-4 py-2.5 text-sm transition-colors relative
+				class="px-4 py-2.5 text-sm transition-colors relative whitespace-nowrap flex-shrink-0
 					{activeTab === tab.id ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'}"
+				style="scroll-margin-inline: 1.5rem;"
 				aria-current={activeTab === tab.id ? 'page' : undefined}
 			>
 				{tab.label}

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -11,11 +11,23 @@
 	const project = $derived(data.project);
 	const fm = $derived(project.frontmatter);
 	const chat = $derived(data.chat);
+	const status = $derived(data.status);
+	const decisions = $derived(data.decisions);
 
 	// Tab is driven by the ?view= search param so URLs are shareable and the
 	// browser back/forward buttons work. The layout highlights the active tab
 	// using the same param. Defaults to 'chats' (Loom #32).
 	const view = $derived($page.url.searchParams.get('view') ?? 'chats');
+
+	// GitHub create-new-file URLs for empty-state CTAs. The same /edit/ path
+	// works whether the file exists or not — GitHub creates a new file when
+	// the path doesn't resolve.
+	const createStatusUrl = $derived(
+		`https://github.com/Nkburdick/ORACLE/new/main/Projects/${fm.slug}?filename=STATUS.md`
+	);
+	const createDecisionsUrl = $derived(
+		`https://github.com/Nkburdick/ORACLE/new/main/Projects/${fm.slug}?filename=DECISIONS.md`
+	);
 
 	async function refreshProject() {
 		await invalidate(`oracle:project:${fm.slug}`);
@@ -59,6 +71,95 @@
 			<article class="prose [&>h1:first-child]:hidden">
 				{@html project.bodyHtml}
 			</article>
+		</div>
+	</PullToRefresh>
+{:else if view === 'status'}
+	<!--
+		Status tab — renders STATUS.md (Layer 4 of the 4-tier doc framework).
+		"Read first when picking up work." Most projects don't have STATUS.md
+		yet — fall through to a friendly empty state with a one-tap "Create"
+		link that opens GitHub's new-file dialog pre-filled with the path.
+	-->
+	<PullToRefresh onrefresh={refreshProject}>
+		<div class="p-6" data-testid="status-content">
+			{#if status}
+				<div class="flex justify-end mb-4">
+					<a
+						href={status.githubEditUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+					>
+						Edit in GitHub <ExternalLink size={12} />
+					</a>
+				</div>
+				<article class="prose [&>h1:first-child]:hidden">
+					{@html status.bodyHtml}
+				</article>
+			{:else}
+				<div class="flex flex-col items-center justify-center py-12 text-center max-w-md mx-auto">
+					<h2 class="text-base font-semibold text-foreground mb-2">No STATUS.md yet</h2>
+					<p class="text-sm text-muted-foreground mb-1">
+						This project hasn't adopted the 4-tier doc framework.
+					</p>
+					<p class="text-xs text-muted-foreground mb-6 leading-relaxed">
+						<code class="text-foreground">STATUS.md</code> is the live state doc — Right Now,
+						Next 3 Actions, Active Sessions, Blocked, Findings, Log. Updated every session.
+					</p>
+					<a
+						href={createStatusUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex items-center gap-1.5 text-sm text-primary hover:underline"
+					>
+						Create STATUS.md on GitHub <ExternalLink size={14} />
+					</a>
+				</div>
+			{/if}
+		</div>
+	</PullToRefresh>
+{:else if view === 'decisions'}
+	<!--
+		Decisions tab — renders DECISIONS.md (Layer 2 of the 4-tier doc framework).
+		Append-only project memory: what we decided and why. Empty state mirrors
+		the Status tab's pattern.
+	-->
+	<PullToRefresh onrefresh={refreshProject}>
+		<div class="p-6" data-testid="decisions-content">
+			{#if decisions}
+				<div class="flex justify-end mb-4">
+					<a
+						href={decisions.githubEditUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+					>
+						Edit in GitHub <ExternalLink size={12} />
+					</a>
+				</div>
+				<article class="prose [&>h1:first-child]:hidden">
+					{@html decisions.bodyHtml}
+				</article>
+			{:else}
+				<div class="flex flex-col items-center justify-center py-12 text-center max-w-md mx-auto">
+					<h2 class="text-base font-semibold text-foreground mb-2">No DECISIONS.md yet</h2>
+					<p class="text-sm text-muted-foreground mb-1">
+						This project hasn't adopted the 4-tier doc framework.
+					</p>
+					<p class="text-xs text-muted-foreground mb-6 leading-relaxed">
+						<code class="text-foreground">DECISIONS.md</code> is append-only project memory —
+						each entry is Decision / Rationale / What changed.
+					</p>
+					<a
+						href={createDecisionsUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex items-center gap-1.5 text-sm text-primary hover:underline"
+					>
+						Create DECISIONS.md on GitHub <ExternalLink size={14} />
+					</a>
+				</div>
+			{/if}
 		</div>
 	</PullToRefresh>
 {/if}

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -103,8 +103,8 @@
 						This project hasn't adopted the 4-tier doc framework.
 					</p>
 					<p class="text-xs text-muted-foreground mb-6 leading-relaxed">
-						<code class="text-foreground">STATUS.md</code> is the live state doc — Right Now,
-						Next 3 Actions, Active Sessions, Blocked, Findings, Log. Updated every session.
+						<code class="text-foreground">STATUS.md</code> is the live state doc — Right Now, Next 3 Actions,
+						Active Sessions, Blocked, Findings, Log. Updated every session.
 					</p>
 					<a
 						href={createStatusUrl}
@@ -147,8 +147,8 @@
 						This project hasn't adopted the 4-tier doc framework.
 					</p>
 					<p class="text-xs text-muted-foreground mb-6 leading-relaxed">
-						<code class="text-foreground">DECISIONS.md</code> is append-only project memory —
-						each entry is Decision / Rationale / What changed.
+						<code class="text-foreground">DECISIONS.md</code> is append-only project memory — each entry
+						is Decision / Rationale / What changed.
 					</p>
 					<a
 						href={createDecisionsUrl}


### PR DESCRIPTION
## Summary

Adds two new tabs to each project page that render `STATUS.md` and `DECISIONS.md` from the 4-tier doc framework. Tab order is now `Chats / Status / SOW / Decisions / Tasks / Artifacts` — Status sits right after the default Chats because the framework treats it as the read-first doc.

Most projects don't have these files yet, so the tabs always render but show a friendly empty state with a one-tap "Create on GitHub" link when the file is missing. As of today's sweep, three projects have full content: `psi-odoo-v8-to-v19-upgrade`, `pai-orchestration`, `stridemind-ai`.

## What changed

- **`src/lib/types/oracle.ts`** — new `ProjectDoc` type (slimmer than `Project` — no frontmatter or DoD parsing, just rendered body).
- **`src/lib/server/oracle-reader.ts`** — new `readProjectStatus(slug)` and `readProjectDecisions(slug)` exports, both delegating to a shared `readProjectDoc(slug, filename)` helper. Same security posture as `readProject()` (slug whitelist + path-inside-base check). Both return `null` when the file doesn't exist.
- **`routes/projects/[slug]/+layout.server.ts`** — parallel-loads project + status + decisions via `Promise.all`. Status and decisions are nullable.
- **`routes/projects/[slug]/+layout.svelte`** — tabs reordered, plus `overflow-x-auto` on the tab bar so 6 tabs scroll cleanly on mobile (~375px viewport). Active tab uses `scroll-margin-inline` so it auto-scrolls into view.
- **`routes/projects/[slug]/+page.svelte`** — new view branches for `?view=status` and `?view=decisions`. Each renders `bodyHtml` in a `prose` article matching the SOW pattern, with the Edit-in-GitHub link. Empty state shows when the file is missing.

## Test plan

- [x] `bun run check` — 0 errors (3 pre-existing warnings)
- [x] `bun run build` — succeeds
- [x] `bun run test:unit` — 80/80 pass
- [x] **Status tab renders content** — `/projects/pai-orchestration?view=status` shows the live STATUS.md (Right Now, Next 3 Actions, Active Sessions, etc.). Verified via QATester + screenshot.
- [x] **Decisions tab renders content** — `/projects/pai-orchestration?view=decisions` shows the rendered DECISIONS.md with date headers + Decision/Rationale/What changed entries. Verified via QATester + screenshot.
- [x] **Empty state for missing file** — `/projects/oracle?view=status` shows the "No STATUS.md yet" friendly state with the copper "Create on GitHub" link. Verified via QATester + screenshot.
- [x] **Mobile tab overflow scrolls horizontally** — at 375px viewport, all 6 tabs render and the bar scrolls horizontally; active tab is not clipped. Verified via QATester + screenshot.

## Visual check

Screenshots at `/tmp/oracle-qa-20260425/s{1,2,3,4}*.png` (local artifacts). Worth eyeballing before merge — the empty-state is the bit most likely to need polish.

## Notes

- No test additions in this PR — existing Playwright suite still covers the layout shell. A follow-up PR can add tab-specific assertions if we want regression coverage for the new views.
- `ORACLE_DATA_PATH` continues to drive disk reads — no schema changes, no DB migrations.
- Pre-existing service-worker registration warning + Pennyworth-not-configured chat banner are unrelated and already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Status and Decisions tabs to project pages for viewing and managing project documentation
  * Implemented empty states with GitHub integration for creating missing Status or Decisions documents
  * Enhanced tab navigation with horizontal scrolling support for improved mobile experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->