### PR TITLE
feat(ui): readability + body font + phase auto-collapse polish bundle

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -17,7 +17,7 @@
 	--secondary: oklch(0.536 0.0398 196.028); /* teal #527575 */
 	--secondary-foreground: oklch(1 0 0);
 	--muted: oklch(0.967 0.0029 264.5419);
-	--muted-foreground: oklch(0.551 0.0234 264.3637);
+	--muted-foreground: oklch(0.44 0.0234 264.3637);
 	--accent: oklch(0.9491 0 0);
 	--accent-foreground: oklch(0.2101 0.0318 264.6645);
 	--destructive: oklch(0.6368 0.2078 25.3313);
@@ -41,7 +41,7 @@
 	--secondary: oklch(0.594 0.0443 196.0233); /* teal (lighter for dark mode) */
 	--secondary-foreground: oklch(0.9851 0 0);
 	--muted: oklch(0.252 0 0);
-	--muted-foreground: oklch(0.683 0 0);
+	--muted-foreground: oklch(0.78 0 0);
 	--accent: oklch(0.252 0 0);
 	--accent-foreground: oklch(0.8109 0 0);
 	--destructive: oklch(0.6368 0.2078 25.3313);
@@ -72,6 +72,8 @@
 	--color-input: var(--input);
 	--color-ring: var(--ring);
 
+	--font-sans:
+		-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Roboto, system-ui, sans-serif;
 	--font-mono:
 		'Geist Mono Variable', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
 		'Courier New', monospace;
@@ -128,8 +130,8 @@
 
 html,
 body {
-	font-family: var(--font-mono);
-	font-size: 14px;
+	font-family: var(--font-sans);
+	font-size: 15px;
 	letter-spacing: 0em;
 	background-color: var(--background);
 	color: var(--foreground);

--- a/src/lib/components/TaskBoard.svelte
+++ b/src/lib/components/TaskBoard.svelte
@@ -65,13 +65,21 @@
 		return name ?? '__unsectioned__';
 	}
 
-	function toggleSection(name: string | null) {
+	function isCollapsed(name: string | null, sectionTasks: Task[]): boolean {
 		const key = collapseKey(name);
-		collapsed[key] = !collapsed[key];
+		// User-toggled state always wins.
+		if (key in collapsed) return collapsed[key];
+		// Default: collapse the section when every task is done — keeps "live"
+		// sections (anything still pending) visible by default and tucks away
+		// fully-completed phases automatically.
+		if (sectionTasks.length === 0) return false;
+		return sectionTasks.every((t) => t.status === 'done');
 	}
 
-	function isCollapsed(name: string | null): boolean {
-		return collapsed[collapseKey(name)] ?? false;
+	function toggleSection(name: string | null, sectionTasks: Task[]) {
+		const key = collapseKey(name);
+		// Invert the *currently visible* state (whether explicit or default).
+		collapsed[key] = !isCollapsed(name, sectionTasks);
 	}
 
 	// ── Optimistic patch from TaskRow ──────────────────────────────────────────
@@ -166,13 +174,13 @@
 					<button
 						type="button"
 						class="group mb-2 flex w-full items-center gap-2 text-left"
-						onclick={() => toggleSection(section.name)}
-						aria-expanded={!isCollapsed(section.name)}
+						onclick={() => toggleSection(section.name, section.tasks)}
+						aria-expanded={!isCollapsed(section.name, section.tasks)}
 					>
 						<ChevronDown
 							size={14}
 							class="flex-shrink-0 text-muted-foreground transition-transform
-								{isCollapsed(section.name) ? '-rotate-90' : ''}"
+								{isCollapsed(section.name, section.tasks) ? '-rotate-90' : ''}"
 						/>
 						<span
 							class="text-xs font-semibold uppercase tracking-wide text-muted-foreground transition-colors group-hover:text-foreground"
@@ -183,7 +191,7 @@
 					</button>
 
 					<!-- Task rows with per-section DnD (no cross-section dragging) -->
-					{#if !isCollapsed(section.name)}
+					{#if !isCollapsed(section.name, section.tasks)}
 						<ul
 							class="flex flex-col divide-y divide-border overflow-hidden rounded-lg border border-border"
 							use:dragHandleZone={{

--- a/src/lib/components/TaskRow.svelte
+++ b/src/lib/components/TaskRow.svelte
@@ -287,14 +287,14 @@
 			}}
 		>
 			<p
-				class="text-sm leading-snug {optimisticStatus === 'done'
+				class="text-sm font-semibold leading-snug {optimisticStatus === 'done'
 					? 'text-muted-foreground line-through'
 					: ''}"
 			>
 				{task.content}
 			</p>
 			{#if task.description}
-				<p class="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{task.description}</p>
+				<p class="mt-1 line-clamp-2 text-sm text-muted-foreground">{task.description}</p>
 			{/if}
 			{#if task.phase}
 				<span

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,7 +51,8 @@ export default defineConfig({
 	server: {
 		fs: {
 			allow: ['..']
-		}
+		},
+		allowedHosts: ['.trycloudflare.com', 'localhost', '127.0.0.1']
 	},
 	resolve: {
 		// Under Vitest, force the browser resolve condition so Svelte 5's


### PR DESCRIPTION
## Summary

Phase 2 polish round for Oracle App — six surgical UI changes Nick + Alfred iterated on during a Cloudflare-tunnel session 2026-04-30.

| # | Change | File |
|---|---|---|
| 1 | Task description font: `text-xs` (12px) → `text-sm` (14px), `mt-0.5` → `mt-1` | `TaskRow.svelte` |
| 2 | Task title weight: default → `font-semibold` (clearer hierarchy vs description) | `TaskRow.svelte` |
| 3 | Body font: Geist Mono → SF / system-ui sans, 14px → 15px | `app.css` |
| 4 | Light mode `--muted-foreground`: 55% → 44% lightness (more contrast) | `app.css` |
| 5 | Dark mode `--muted-foreground`: 68% → 78% lightness (more contrast) | `app.css` |
| 6 | Phase sections auto-collapse when all tasks done, expand when anything pending | `TaskBoard.svelte` |
| (dev only) | `server.allowedHosts` for Cloudflare quick tunnels | `vite.config.ts` |

## Why

Nick during 2026-04-27 EOD soak: *"hard to read; dark mode better than light, but Tasks area description font needs to be bigger; eyes-at-47 want more contrast in BOTH modes and a slightly easier-to-read body font."*

Plus 2026-04-30: *"I would like the phases to be collapsed if everything is clicked off ... default to being expanded if there's something that still needs to be checked off."*

## Phase auto-collapse behavior

- Section with **every task done** → defaults collapsed
- Section with **anything pending** → defaults expanded  
- Section with **no tasks** → defaults expanded (so empty-state is visible)
- **User toggle always wins** — clicking the chevron inverts whatever's currently showing and snapshots it (no "user clicks expand but nothing happens" bug)
- When the last pending task in a section is marked done, that section auto-collapses on the spot

## Discovery during the scan

- **GH #35 (auto-scroll chat + new-message pill)** is already implemented in both project + area `+page.svelte` chat thread files (AC-15/16/17 referenced in code). Stale task entry — will be marked done in `tasks.json` separately.

## Test plan

- [x] Dev-server preview tested on iPhone via Cloudflare Tunnel (`https://reserves-pump-action-patents.trycloudflare.com`)
- [x] Light mode: task descriptions + phase labels noticeably more readable
- [x] Dark mode: muted text contrast improved without losing hierarchy
- [x] Title vs description distinction reads cleanly at a glance
- [x] Phase auto-collapse: Phase 0/1 tucked away on load, Phase 2/3 expanded, manual toggle works in both directions
- [ ] Production smoke test on `oracle.aptoworks.cloud` after merge

## Closes

- `pai-p2-ux-readability-polish` (PAI Orch v1 Phase 2)
- `pai-p2-ux-collapse-phases` (PAI Orch v1 Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated muted text colors in both light and dark themes for improved visual hierarchy.
  * Improved base typography with a cleaner system sans-serif font and optimized sizing.
  * Enhanced task display typography for better readability.

* **Improvements**
  * Task board sections now intelligently collapse when all tasks are marked complete, while respecting manual toggles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->