### PR TITLE
fix(chat): keep viewport pinned to bottom while assistant streams

### DIFF
--- a/src/routes/areas/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/areas/[slug]/chats/[threadId]/+page.svelte
@@ -270,6 +270,18 @@
 						messages = messages.map((m) =>
 							m.id === assistantId ? { ...m, content: fullText } : m
 						);
+						// Keep viewport pinned during streaming if user is at the bottom;
+						// surface the new-messages pill if they've scrolled up. The append-path
+						// $effect doesn't fire here — messages.length is unchanged across tokens.
+						if (isScrolledToBottom) {
+							tick().then(() => {
+								if (messagesContainerEl && isScrolledToBottom) {
+									messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
+								}
+							});
+						} else {
+							hasNewMessages = true;
+						}
 					} else if (eventType === 'done') {
 						fullText = data.fullText;
 						messages = messages.map((m) =>

--- a/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
+++ b/src/routes/projects/[slug]/chats/[threadId]/+page.svelte
@@ -270,6 +270,18 @@
 						messages = messages.map((m) =>
 							m.id === assistantId ? { ...m, content: fullText } : m
 						);
+						// Keep viewport pinned during streaming if user is at the bottom;
+						// surface the new-messages pill if they've scrolled up. The append-path
+						// $effect doesn't fire here — messages.length is unchanged across tokens.
+						if (isScrolledToBottom) {
+							tick().then(() => {
+								if (messagesContainerEl && isScrolledToBottom) {
+									messagesContainerEl.scrollTop = messagesContainerEl.scrollHeight;
+								}
+							});
+						} else {
+							hasNewMessages = true;
+						}
 					} else if (eventType === 'done') {
 						fullText = data.fullText;
 						messages = messages.map((m) =>


### PR DESCRIPTION
## Summary

Fixes the chat scroller dropping behind the streaming text. While the assistant streams a long response token-by-token, the existing auto-scroll `\$effect` (length-based) doesn't fire — so lines drift below the viewport and the user has to manually scroll.

## Why

Caught 2026-04-30 EOD when Nick asked *"So you said the chat streaming scroller was already implemented, right?"* — verifying revealed the original implementation only handled the **new-message-append** case. Streaming mutates the assistant message's `content` field within the same array entry; `messages.length` is unchanged, so the `\$effect` at line 134 silently skips the streaming case.

## What changed

In the SSE `token` event branch of both chat thread files, after applying the content patch:

- If user is at bottom (`isScrolledToBottom`) → `tick().then(() => scrollTop = scrollHeight)`
- Else → `hasNewMessages = true` (lights up the existing pill, lets user tap to catch up)

Identical change in both files since they have identical streaming structure:
- `src/routes/projects/[slug]/chats/[threadId]/+page.svelte`
- `src/routes/areas/[slug]/chats/[threadId]/+page.svelte`

## What's NOT changed

- The append-path `\$effect` still handles brand-new messages
- The `done`-event post-stream scroll still runs
- User-scrolled-up state continues to surface the pill (no auto-yank)

## Test plan

- [x] `bun run check` clean (0 errors, 3 pre-existing warnings unrelated)
- [ ] Send a long prompt to an assistant and watch it stream — viewport should track the trailing line
- [ ] Mid-stream, scroll up manually — verify auto-scroll stops, pill appears, taps to bottom
- [ ] Compare project + area chat — both behave identically

## Notes

- After merge, run `cd /opt/oracle-stack && docker compose pull oracle && docker compose up -d oracle` on KVM2 (oracle-app deploy is manual until `pai-p3-infra-007` ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced scroll behavior during message streaming across chat interfaces. The viewport now automatically maintains position at the bottom when new content arrives, and displays a "new messages" indicator when users have scrolled up, ensuring better visibility of incoming messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->