### PR TITLE
ci(deploy): auto-deploy oracle-app to KVM2 on merge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,3 +28,72 @@ jobs:
           tags: |
             ghcr.io/nkburdick/oracle-app:latest
             ghcr.io/nkburdick/oracle-app:${{ github.sha }}
+
+  deploy-to-kvm2:
+    needs: build-push
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Pull + recreate oracle on KVM2
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.KVM2_HOST }}
+          username: root
+          key: ${{ secrets.KVM2_ROOT_SSH_KEY }}
+          timeout: 60s
+          command_timeout: 8m
+          script: |
+            set -e
+            cd /opt/oracle-stack
+            docker compose pull oracle
+            docker compose up -d --force-recreate oracle
+
+            # Poll healthcheck until container settles (compose.yml: start_period=10s, interval=30s)
+            for _ in $(seq 1 60); do
+              H=$(docker inspect oracle --format '{{.State.Health.Status}}' 2>/dev/null || echo missing)
+              [ "$H" = "healthy" ] && break
+              [ "$H" = "missing" ] && { echo "ERROR: oracle container not found"; exit 1; }
+              sleep 2
+            done
+
+            read STATUS IMAGE_ID CREATED HEALTH < <(docker inspect oracle \
+              --format '{{.State.Status}} {{slice .Image 7 19}} {{.Created}} {{.State.Health.Status}}')
+
+            if [ "$STATUS" = "running" ] && [ "$HEALTH" = "healthy" ]; then
+              echo "oracle deployed: image=$IMAGE_ID created=$CREATED status=$STATUS health=$HEALTH"
+            else
+              echo "ERROR: oracle deploy failed: status=$STATUS health=$HEALTH image=$IMAGE_ID"
+              exit 1
+            fi
+
+      - name: Retry on failure
+        if: failure()
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.KVM2_HOST }}
+          username: root
+          key: ${{ secrets.KVM2_ROOT_SSH_KEY }}
+          timeout: 90s
+          command_timeout: 8m
+          script: |
+            set -e
+            cd /opt/oracle-stack
+            docker compose pull oracle
+            docker compose up -d --force-recreate oracle
+
+            for _ in $(seq 1 60); do
+              H=$(docker inspect oracle --format '{{.State.Health.Status}}' 2>/dev/null || echo missing)
+              [ "$H" = "healthy" ] && break
+              [ "$H" = "missing" ] && { echo "ERROR (retry): oracle container not found"; exit 1; }
+              sleep 2
+            done
+
+            read STATUS IMAGE_ID CREATED HEALTH < <(docker inspect oracle \
+              --format '{{.State.Status}} {{slice .Image 7 19}} {{.Created}} {{.State.Health.Status}}')
+
+            if [ "$STATUS" = "running" ] && [ "$HEALTH" = "healthy" ]; then
+              echo "oracle deployed (retry): image=$IMAGE_ID created=$CREATED status=$STATUS health=$HEALTH"
+            else
+              echo "ERROR (retry): oracle deploy failed: status=$STATUS health=$HEALTH image=$IMAGE_ID"
+              exit 1
+            fi


### PR DESCRIPTION
## Summary

Closes the manual-deploy gap caught 2026-04-30: today's `docker.yml` only builds + pushes to `ghcr.io`, leaving production on whatever image was last manually pulled. After this PR, every merge to `main` auto-deploys.

PAI Orch task: `pai-p3-infra-007`

- Adds `deploy-to-kvm2` job — runs after `build-push` succeeds
- SSHes into `root@KVM2`, runs `docker compose pull && up -d --force-recreate oracle` on `/opt/oracle-stack`
- Verifies via healthcheck poll + coalesced `docker inspect` (status=running + health=healthy)
- One retry on failure (mirrors Pennyworth's `Deploy Pennyworth` workflow)

## Setup already done (no action needed before merge)

| Item | Status |
|---|---|
| New SSH keypair `oracle-app-deploy-ci` (ed25519) | Generated locally |
| Public key added to `root@KVM2:/root/.ssh/authorized_keys` | Done — fingerprint `SHA256:4eLL4fHWCO...` |
| Local SSH test with new key | Passed (`whoami → root`, `docker compose ps → oracle Up healthy`) |
| `KVM2_HOST` repo secret | Set (`31.220.21.243`) |
| `KVM2_ROOT_SSH_KEY` repo secret | Set (private key contents) |

## Heads up — first auto-deploy fires on merge

The instant this PR merges, the workflow runs end-to-end (build-push + deploy-to-kvm2). The deploy job will pull the just-built image and recreate the `oracle` container on KVM2. Brief blip (a few seconds) on https://oracle.aptoworks.cloud is expected. Traefik + container `restart: unless-stopped` + healthcheck cover it.

If something goes sideways, the manual fallback still works:
```
ssh root@31.220.21.243 'cd /opt/oracle-stack && docker compose pull oracle && docker compose up -d oracle'
```

## /simplify pass applied

Three reviewer agents flagged 6 quality/efficiency issues; all fixed before commit:
- Healthcheck poll instead of `sleep 5`
- Single coalesced `docker inspect` instead of three separate calls
- Template `{{slice .Image 7 19}}` instead of fragile `cut -c8-19`
- Explicit `STATUS=running && HEALTH=healthy` check
- Retry block now also runs full verification (was silently passing on broken container)
- Avoided em-dash in error messages (renders oddly in GH Actions logs)

Skipped (intentional): digest-gate optimization (over-engineering for daily cadence), removing pull from retry (idempotent + cheap).

## Test plan

- [ ] After merge, watch the `Docker Build & Push` workflow run on Actions tab
- [ ] Confirm `deploy-to-kvm2` job logs show `oracle deployed: image=<sha> ... status=running health=healthy`
- [ ] Verify container creation timestamp updated: `ssh root@31.220.21.243 'docker inspect oracle --format "{{.Created}}"'`
- [ ] Smoke test: `curl -I https://oracle.aptoworks.cloud/login` returns `HTTP/2 200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Implemented automated deployment pipeline with built-in health verification and automatic retry on failure to ensure reliable service updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->