### PR TITLE
fix(reader): accept deferred + pr-open task statuses

### DIFF
--- a/src/lib/components/TaskDetail.svelte
+++ b/src/lib/components/TaskDetail.svelte
@@ -2,14 +2,24 @@
 	import { X, GitBranch, ExternalLink, AlertCircle } from 'lucide-svelte';
 	import type { Task, TaskStatus, TaskAssignee } from '$lib/types/oracle-task.js';
 
-	const STATUS_ORDER: TaskStatus[] = ['backlog', 'ready', 'in_progress', 'review', 'done'];
+	const STATUS_ORDER: TaskStatus[] = [
+		'backlog',
+		'ready',
+		'in_progress',
+		'pr-open',
+		'review',
+		'done',
+		'deferred'
+	];
 
 	const STATUS_LABELS: Record<TaskStatus, string> = {
 		backlog: 'Backlog',
 		ready: 'Ready',
 		in_progress: 'In progress',
+		'pr-open': 'PR open',
 		review: 'Review',
-		done: 'Done'
+		done: 'Done',
+		deferred: 'Deferred'
 	};
 
 	const ASSIGNEES: TaskAssignee[] = ['nick', 'alfred', 'pennyworth', 'forge'];

--- a/src/lib/components/TaskRow.svelte
+++ b/src/lib/components/TaskRow.svelte
@@ -20,22 +20,34 @@
 
 	// ── Status helpers ────────────────────────────────────────────────────────
 
-	const STATUS_ORDER: TaskStatus[] = ['backlog', 'ready', 'in_progress', 'review', 'done'];
+	const STATUS_ORDER: TaskStatus[] = [
+		'backlog',
+		'ready',
+		'in_progress',
+		'pr-open',
+		'review',
+		'done',
+		'deferred'
+	];
 
 	const STATUS_LABELS: Record<TaskStatus, string> = {
 		backlog: 'Backlog',
 		ready: 'Ready',
 		in_progress: 'In progress',
+		'pr-open': 'PR open',
 		review: 'Review',
-		done: 'Done'
+		done: 'Done',
+		deferred: 'Deferred'
 	};
 
 	const STATUS_COLORS: Record<TaskStatus, string> = {
 		backlog: 'bg-muted text-muted-foreground',
 		ready: 'bg-secondary/20 text-secondary',
 		in_progress: 'bg-primary/15 text-primary',
+		'pr-open': 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
 		review: 'bg-accent text-accent-foreground border border-border',
-		done: 'bg-muted text-muted-foreground'
+		done: 'bg-muted text-muted-foreground',
+		deferred: 'bg-muted/50 text-muted-foreground italic'
 	};
 
 	// ── Assignee helpers ──────────────────────────────────────────────────────

--- a/src/lib/server/oracle-reader.ts
+++ b/src/lib/server/oracle-reader.ts
@@ -34,7 +34,15 @@ import {
 import type { Project, ProjectDoc, Area, SidebarItem, DashboardCard } from '$lib/types/oracle.js';
 import type { Task, TasksFile } from '$lib/types/oracle-task.js';
 
-const VALID_STATUSES = new Set(['backlog', 'ready', 'in_progress', 'review', 'done']);
+const VALID_STATUSES = new Set([
+	'backlog',
+	'ready',
+	'in_progress',
+	'pr-open',
+	'review',
+	'done',
+	'deferred'
+]);
 const VALID_ASSIGNEES = new Set(['nick', 'alfred', 'pennyworth', 'forge']);
 
 function isValidTask(t: unknown): t is Task {

--- a/src/lib/types/oracle-task.ts
+++ b/src/lib/types/oracle-task.ts
@@ -8,7 +8,14 @@
  * Verbatim mirror of Pennyworth `src/types/oracle-task.ts`.
  */
 
-export type TaskStatus = 'backlog' | 'ready' | 'in_progress' | 'review' | 'done';
+export type TaskStatus =
+	| 'backlog'
+	| 'ready'
+	| 'in_progress'
+	| 'pr-open'
+	| 'review'
+	| 'done'
+	| 'deferred';
 
 export type TaskAssignee = 'nick' | 'alfred' | 'pennyworth' | 'forge';
 


### PR DESCRIPTION
## Summary

`src/lib/server/oracle-reader.ts` `VALID_STATUSES` set silently dropped tasks whose status was outside `{backlog, ready, in_progress, review, done}`. Doc tasks #7 (`pr-open`) + #22 / #33 / #34 / #35 (`deferred`) were rejected → Phase 6 disappeared from view (all 3 tasks deferred), Phase 1 + Phase 3 each lost one task.

Surgical fix: extend `TaskStatus` type + `VALID_STATUSES` validator + display constants (`STATUS_ORDER`, `STATUS_LABELS`, `STATUS_COLORS`) across `TaskRow.svelte` and `TaskDetail.svelte`.

- `pr-open`: blue badge ("PR open"), order between `in_progress` and `review`
- `deferred`: muted-italic badge ("Deferred"), order at end

Companion fix in Pennyworth: https://github.com/Nkburdick/pennyworth/pull/102 (keeps types in sync — `oracle-task.ts` is explicitly a "verbatim mirror of Pennyworth").

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] After merge + auto-deploy: Phase 6 visible in Oracle App for doc-longevity project (3 deferred tasks)
- [ ] After merge: Phase 1 shows 7 tasks (was 6 — #7 web-search now visible with pr-open badge)
- [ ] After merge: Phase 3 shows 7 tasks (was 6 — #22 transcript RAG now visible with deferred badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced two new task statuses: "PR Open" and "Deferred". Tasks can now utilize these statuses for improved workflow tracking, complete with dedicated labels, color-coded visual indicators, and integrated support throughout all task management views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nkburdick/oracle-app/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->