### PR TITLE
feat(sidebar): collapsible Projects/Areas/Archive sections

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -8,9 +8,10 @@
 	interface Props {
 		projects: SidebarItem[];
 		areas: SidebarItem[];
+		archived?: SidebarItem[];
 	}
 
-	const { projects, areas }: Props = $props();
+	const { projects, areas, archived = [] }: Props = $props();
 
 	const currentPath = $derived($page.url.pathname);
 
@@ -63,47 +64,98 @@
 			<span>Dashboard</span>
 		</a>
 
-		<!-- Projects section -->
-		<div class="mt-3 mb-1 px-2">
-			<span class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
-				>[PROJECTS]</span
+		<!-- Projects section (collapsible, default open) -->
+		<details open class="group/projects mt-3" data-testid="sidebar-section-projects">
+			<summary
+				class="flex items-center gap-1 mb-1 px-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden hover:text-foreground"
 			>
-		</div>
+				<span
+					class="text-[10px] text-muted-foreground transition-transform group-open/projects:rotate-90"
+					>▸</span
+				>
+				<span class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+					>[PROJECTS]</span
+				>
+			</summary>
+			<div class="flex flex-col gap-0.5">
+				{#each projects as project (project.slug)}
+					<a
+						href="/projects/{project.slug}"
+						class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors group
+							{isActiveProject(project.slug)
+							? 'bg-secondary/20 text-foreground border-l-[3px] border-l-primary pl-[5px]'
+							: 'text-muted-foreground hover:text-foreground hover:bg-accent'}"
+						data-testid="sidebar-project"
+					>
+						<StatusIndicator state={project.state} size={6} />
+						<span class="truncate">{project.title}</span>
+					</a>
+				{/each}
+			</div>
+		</details>
 
-		{#each projects as project (project.slug)}
-			<a
-				href="/projects/{project.slug}"
-				class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors group
-					{isActiveProject(project.slug)
-					? 'bg-secondary/20 text-foreground border-l-[3px] border-l-primary pl-[5px]'
-					: 'text-muted-foreground hover:text-foreground hover:bg-accent'}"
-				data-testid="sidebar-project"
+		<!-- Areas section (collapsible, default open) -->
+		<details open class="group/areas mt-4" data-testid="sidebar-section-areas">
+			<summary
+				class="flex items-center gap-1 mb-1 px-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden hover:text-foreground"
 			>
-				<StatusIndicator state={project.state} size={6} />
-				<span class="truncate">{project.title}</span>
-			</a>
-		{/each}
+				<span
+					class="text-[10px] text-muted-foreground transition-transform group-open/areas:rotate-90"
+					>▸</span
+				>
+				<span class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+					>[AREAS]</span
+				>
+			</summary>
+			<div class="flex flex-col gap-0.5">
+				{#each areas as area (area.slug)}
+					<a
+						href="/areas/{area.slug}"
+						class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors
+							{isActiveArea(area.slug)
+							? 'bg-secondary/20 text-foreground border-l-[3px] border-l-primary pl-[5px]'
+							: 'text-muted-foreground hover:text-foreground hover:bg-accent'}"
+						data-testid="sidebar-area"
+					>
+						<StatusIndicator state="area" size={6} />
+						<span class="truncate">{area.title}</span>
+					</a>
+				{/each}
+			</div>
+		</details>
 
-		<!-- Areas section -->
-		<div class="mt-4 mb-1 px-2">
-			<span class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
-				>[AREAS]</span
-			>
-		</div>
-
-		{#each areas as area (area.slug)}
-			<a
-				href="/areas/{area.slug}"
-				class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors
-					{isActiveArea(area.slug)
-					? 'bg-secondary/20 text-foreground border-l-[3px] border-l-primary pl-[5px]'
-					: 'text-muted-foreground hover:text-foreground hover:bg-accent'}"
-				data-testid="sidebar-area"
-			>
-				<StatusIndicator state="area" size={6} />
-				<span class="truncate">{area.title}</span>
-			</a>
-		{/each}
+		<!-- Archive section (collapsible, default closed). Only shown when at
+		     least one project is in the `completed` state. -->
+		{#if archived.length > 0}
+			<details class="group/archive mt-4" data-testid="sidebar-section-archive">
+				<summary
+					class="flex items-center gap-1 mb-1 px-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden hover:text-foreground"
+				>
+					<span
+						class="text-[10px] text-muted-foreground transition-transform group-open/archive:rotate-90"
+						>▸</span
+					>
+					<span class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+						>[ARCHIVE] ({archived.length})</span
+					>
+				</summary>
+				<div class="flex flex-col gap-0.5">
+					{#each archived as project (project.slug)}
+						<a
+							href="/projects/{project.slug}"
+							class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors opacity-70 hover:opacity-100
+								{isActiveProject(project.slug)
+								? 'bg-secondary/20 text-foreground border-l-[3px] border-l-primary pl-[5px]'
+								: 'text-muted-foreground hover:text-foreground hover:bg-accent'}"
+							data-testid="sidebar-archive-project"
+						>
+							<StatusIndicator state={project.state} size={6} />
+							<span class="truncate">{project.title}</span>
+						</a>
+					{/each}
+				</div>
+			</details>
+		{/if}
 
 		<!-- Spacer -->
 		<div class="flex-1"></div>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -29,7 +29,7 @@ export const load: LayoutServerLoad = async ({ depends, cookies, url }) => {
 	depends('oracle:projects');
 	depends('oracle:areas');
 	const [allProjects, areas] = await Promise.all([readAllProjects(), readAllAreas()]);
-	// Hide completed projects from the sidebar — surfaced on /projects/archive instead
 	const projects = allProjects.filter((p) => p.state !== 'completed');
-	return { projects, areas };
+	const archived = allProjects.filter((p) => p.state === 'completed');
+	return { projects, areas, archived };
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -64,7 +64,7 @@
 
 <div class="app-shell flex h-screen overflow-hidden bg-background text-foreground">
 	<!-- Desktop sidebar -->
-	<Sidebar projects={data.projects} areas={data.areas} />
+	<Sidebar projects={data.projects} areas={data.areas} archived={data.archived} />
 
 	<!-- Main content area — safe-area-inset-top for standalone PWA on notch devices -->
 	<main class="app-main flex-1 overflow-y-auto pt-safe-area pb-16 lg:pb-0">


### PR DESCRIPTION
## Summary

Sidebar now has three collapsible sections:

- **Projects** — `<details open>` (default expanded)
- **Areas** — `<details open>` (default expanded)
- **Archive** — `<details>` (default collapsed), only rendered when ≥1 completed project exists

Click the section header (▸ chevron + label) to toggle. State persists across in-app navigation because the root layout doesn't remount; full reload returns to defaults.

Archive items get opacity-70 "tucked away" treatment matching the inline /projects archive.

## Test plan

- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean
- [ ] Manual: sidebar shows 3 sections; Projects + Areas expanded, Archive collapsed
- [ ] Manual: clicking [PROJECTS] header collapses the project list
- [ ] Manual: opening [ARCHIVE] shows owen-first-car with reduced opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Archive section to sidebar displaying completed items with count indicator.
  * Made Projects and Areas sections in sidebar collapsible.

* **UI/UX Improvements**
  * Archive items display with subtle styling, increasing opacity on hover for better visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nkburdick/oracle-app/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->